### PR TITLE
feat: scroll-lock, session restore, and visual pane differentiation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,17 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "location" : "https://github.com/k3rnelpan11c/SwiftTerm",
       "state" : {
-        "revision" : "3c45fdcfcf4395c72d2a4ee23c0bce79017b5391",
-        "version" : "1.12.0"
+        "branch" : "flock-scroll-lock",
+        "revision" : "f9a8f3565f762eda39ceb3b01884cbbcd41b01c1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "Flock",
     platforms: [.macOS(.v13)],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.0.0")
+        .package(url: "https://github.com/k3rnelpan11c/SwiftTerm", branch: "flock-scroll-lock")
     ],
     targets: [
         .executableTarget(

--- a/Sources/Flock/ClaudeOutputParser.swift
+++ b/Sources/Flock/ClaudeOutputParser.swift
@@ -69,9 +69,11 @@ final class ClaudeOutputParser {
     private(set) var actions: [ActionEntry] = []
     var onStateChange: ((AgentState) -> Void)?
     var onAction: ((ActionEntry) -> Void)?
+    var onTrustPrompt: (() -> Void)?
 
     private var idleTimer: Timer?
     private let idleTimeout: TimeInterval = 4.0
+    private var trustPromptFired = false
 
     deinit {
         idleTimer?.invalidate()
@@ -141,9 +143,34 @@ final class ClaudeOutputParser {
 
     // MARK: - Feed
 
+    // Buffer for trust prompt detection across small chunks
+    private var trustBuffer = ""
+
     func feed(_ text: String) {
         assert(Thread.isMainThread, "ClaudeOutputParser.feed must be called from main thread")
         let clean = stripAnsi(text)
+
+        // Trust prompt detection: buffer text across chunks for reliable matching.
+        // Claude's TUI uses cursor positioning, so after ANSI stripping words may
+        // be concatenated without spaces. We normalize by lowercasing.
+        if !trustPromptFired {
+            trustBuffer += clean
+            if trustBuffer.count > 4000 { trustBuffer = String(trustBuffer.suffix(2000)) }
+            let lower = trustBuffer.lowercased()
+            if lower.contains("trust this folder")
+                || lower.contains("trustthisfolder")
+                || lower.contains("i trust this")
+                || lower.contains("safety check")
+                || lower.contains("safetycheck") {
+                trustPromptFired = true
+                trustBuffer = ""
+                // Small delay to let the TUI fully render before sending Enter
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                    self?.onTrustPrompt?()
+                }
+            }
+        }
+
         guard clean.count > 5 else { return }  // skip tiny fragments
 
         // Collapse whitespace and extract a compact string to search

--- a/Sources/Flock/CommandPalette.swift
+++ b/Sources/Flock/CommandPalette.swift
@@ -203,6 +203,12 @@ class CommandPalette {
                 guard idx >= 0, idx < mgr.panes.count else { return }
                 (mgr.panes[idx] as? TerminalPane)?.toggleChangeLog()
             },
+            CommandAction(name: "Toggle Usage Stats", shortcut: "⌘⇧U", category: "View") { [weak self] in
+                guard let mgr = self?.paneManager else { return }
+                let idx = mgr.activePaneIndex
+                guard idx >= 0, idx < mgr.panes.count else { return }
+                (mgr.panes[idx] as? TerminalPane)?.toggleCostStats()
+            },
             CommandAction(name: "Toggle Memory", shortcut: "⌘⇧M", category: "View") { [weak self] in
                 guard let win = self?.window else { return }
                 (NSApp.delegate as? AppDelegate)?.memorySidebar.toggle(in: win)

--- a/Sources/Flock/CostStatsView.swift
+++ b/Sources/Flock/CostStatsView.swift
@@ -1,0 +1,242 @@
+import AppKit
+
+/// Floating overlay panel showing detailed cost & usage stats for a Claude session.
+/// Styled to match ChangeLogView / Flock's overlay design language.
+final class CostStatsView: NSView {
+
+    var onClose: (() -> Void)?
+
+    let panelWidth: CGFloat = 260
+    private let headerHeight: CGFloat = 28
+    private let rowHeight: CGFloat = 22
+    private let sectionHeaderHeight: CGFloat = 26
+    private let padH: CGFloat = 12
+
+    // Data
+    private var sessionCost: Double = 0
+    private var sessionTokens: Int = 0
+    private var sessionInputTokens: Int = 0
+    private var sessionOutputTokens: Int = 0
+    private var sessionCacheReadTokens: Int = 0
+    private var sessionCacheCreateTokens: Int = 0
+    private var dailyCost: Double = 0
+    private var dailyTokens: Int = 0
+    private var limitPercent: Int = 0
+    private var limitResetText: String = ""
+    private var sessionCount: Int = 0
+
+    // Subviews
+    private let headerLabel = NSTextField(labelWithString: "Usage & Costs")
+    private let closeButton = NSButton(title: "×", target: nil, action: nil)
+    private let contentStack = NSStackView()
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.backgroundColor = Theme.surface.withAlphaComponent(0.95).cgColor
+        layer?.borderWidth = 1
+        layer?.borderColor = Theme.divider.cgColor
+        layer?.cornerRadius = 8
+        layer?.shadowColor = NSColor.black.cgColor
+        layer?.shadowOpacity = 0.15
+        layer?.shadowRadius = 12
+        layer?.shadowOffset = CGSize(width: 0, height: -4)
+
+        // Header
+        headerLabel.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+        headerLabel.textColor = Theme.textSecondary
+        headerLabel.isBezeled = false
+        headerLabel.drawsBackground = false
+        headerLabel.isEditable = false
+        addSubview(headerLabel)
+
+        closeButton.isBordered = false
+        closeButton.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        closeButton.contentTintColor = Theme.textTertiary
+        closeButton.target = self
+        closeButton.action = #selector(closeTapped)
+        addSubview(closeButton)
+
+        // Content stack
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.spacing = 0
+        addSubview(contentStack)
+    }
+
+    @objc private func closeTapped() { onClose?() }
+
+    // MARK: - Data Update
+
+    func update(
+        sessionCost: Double, sessionTokens: Int,
+        inputTokens: Int, outputTokens: Int,
+        cacheReadTokens: Int, cacheCreateTokens: Int
+    ) {
+        self.sessionCost = sessionCost
+        self.sessionTokens = sessionTokens
+        self.sessionInputTokens = inputTokens
+        self.sessionOutputTokens = outputTokens
+        self.sessionCacheReadTokens = cacheReadTokens
+        self.sessionCacheCreateTokens = cacheCreateTokens
+
+        // Global daily stats from UsageTracker
+        let tracker = UsageTracker.shared
+        self.dailyCost = tracker.today.costUSD
+        self.dailyTokens = tracker.today.totalTokens
+        self.sessionCount = tracker.today.sessionCount
+        self.limitPercent = tracker.limits.available ? min(max(Int(tracker.limits.fiveHourPercent), 0), 999) : -1
+        self.limitResetText = tracker.statusText
+
+        rebuildContent()
+    }
+
+    private func rebuildContent() {
+        contentStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        // Session section
+        addSectionHeader("This Session")
+        addRow("Cost", formatCost(sessionCost))
+        addRow("Tokens", formatTokens(sessionTokens))
+        addRow("  Input", formatTokens(sessionInputTokens), dimLabel: true)
+        addRow("  Output", formatTokens(sessionOutputTokens), dimLabel: true)
+        if sessionCacheReadTokens > 0 {
+            addRow("  Cache read", formatTokens(sessionCacheReadTokens), dimLabel: true)
+        }
+        if sessionCacheCreateTokens > 0 {
+            addRow("  Cache write", formatTokens(sessionCacheCreateTokens), dimLabel: true)
+        }
+
+        addSpacer(8)
+
+        // Daily section
+        addSectionHeader("Today")
+        addRow("Total cost", formatCost(dailyCost))
+        addRow("Total tokens", formatTokens(dailyTokens))
+        addRow("Sessions", "\(sessionCount)")
+
+        // Rate limits
+        if limitPercent >= 0 {
+            addSpacer(8)
+            addSectionHeader("Rate Limit")
+            let pctColor: NSColor = limitPercent >= 80 ? NSColor(hex: 0xC75450) : Theme.textPrimary
+            addRow("5h usage", "\(limitPercent)%", valueColor: pctColor)
+            if !limitResetText.isEmpty {
+                addRow("Status", limitResetText, dimLabel: true)
+            }
+        }
+
+        resizeSubviews(withOldSize: bounds.size)
+    }
+
+    // MARK: - Row builders
+
+    private func addSectionHeader(_ title: String) {
+        let label = NSTextField(labelWithString: title)
+        label.font = NSFont.systemFont(ofSize: 10, weight: .semibold)
+        label.textColor = Theme.textTertiary
+        label.isBezeled = false
+        label.drawsBackground = false
+        label.isEditable = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSView()
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addSubview(label)
+        NSLayoutConstraint.activate([
+            row.heightAnchor.constraint(equalToConstant: sectionHeaderHeight),
+            row.widthAnchor.constraint(equalToConstant: panelWidth - padH * 2),
+            label.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            label.bottomAnchor.constraint(equalTo: row.bottomAnchor, constant: -4),
+        ])
+        contentStack.addArrangedSubview(row)
+    }
+
+    private func addRow(_ label: String, _ value: String, dimLabel: Bool = false, valueColor: NSColor? = nil) {
+        let labelField = NSTextField(labelWithString: label)
+        labelField.font = NSFont.systemFont(ofSize: 11, weight: .regular)
+        labelField.textColor = dimLabel ? Theme.textTertiary : Theme.textSecondary
+        labelField.isBezeled = false
+        labelField.drawsBackground = false
+        labelField.isEditable = false
+        labelField.lineBreakMode = .byTruncatingTail
+        labelField.translatesAutoresizingMaskIntoConstraints = false
+
+        let valueField = NSTextField(labelWithString: value)
+        valueField.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        valueField.textColor = valueColor ?? Theme.textPrimary
+        valueField.alignment = .right
+        valueField.isBezeled = false
+        valueField.drawsBackground = false
+        valueField.isEditable = false
+        valueField.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSView()
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addSubview(labelField)
+        row.addSubview(valueField)
+
+        NSLayoutConstraint.activate([
+            row.heightAnchor.constraint(equalToConstant: rowHeight),
+            row.widthAnchor.constraint(equalToConstant: panelWidth - padH * 2),
+            labelField.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            labelField.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labelField.widthAnchor.constraint(lessThanOrEqualToConstant: 120),
+            valueField.trailingAnchor.constraint(equalTo: row.trailingAnchor),
+            valueField.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            valueField.leadingAnchor.constraint(greaterThanOrEqualTo: labelField.trailingAnchor, constant: 4),
+        ])
+        contentStack.addArrangedSubview(row)
+    }
+
+    private func addSpacer(_ height: CGFloat) {
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.heightAnchor.constraint(equalToConstant: height).isActive = true
+        spacer.widthAnchor.constraint(equalToConstant: panelWidth - padH * 2).isActive = true
+        contentStack.addArrangedSubview(spacer)
+    }
+
+    // MARK: - Formatting
+
+    private func formatCost(_ cost: Double) -> String {
+        if cost == 0 { return "$0.00" }
+        if cost < 0.01 { return "<$0.01" }
+        if cost < 10 { return String(format: "$%.2f", cost) }
+        return String(format: "$%.0f", cost)
+    }
+
+    private func formatTokens(_ tokens: Int) -> String {
+        if tokens < 1000 { return "\(tokens)" }
+        if tokens < 1_000_000 { return String(format: "%.1fK", Double(tokens) / 1000) }
+        return String(format: "%.1fM", Double(tokens) / 1_000_000)
+    }
+
+    // MARK: - Layout
+
+    func idealHeight() -> CGFloat {
+        let contentH = contentStack.fittingSize.height
+        return headerHeight + contentH + 12  // 12px bottom padding
+    }
+
+    override func resizeSubviews(withOldSize oldSize: NSSize) {
+        headerLabel.frame = CGRect(x: padH, y: 4, width: panelWidth - 40, height: headerHeight - 4)
+        closeButton.frame = CGRect(x: panelWidth - 26, y: 4, width: 20, height: 20)
+        contentStack.frame = CGRect(x: padH, y: headerHeight, width: panelWidth - padH * 2, height: bounds.height - headerHeight - 8)
+    }
+
+    // MARK: - Theme
+
+    func applyTheme() {
+        layer?.backgroundColor = Theme.surface.withAlphaComponent(0.95).cgColor
+        layer?.borderColor = Theme.divider.cgColor
+        headerLabel.textColor = Theme.textSecondary
+        closeButton.contentTintColor = Theme.textTertiary
+    }
+}

--- a/Sources/Flock/FlockPane.swift
+++ b/Sources/Flock/FlockPane.swift
@@ -26,7 +26,11 @@ class FlockPane: NSView {
     let titleBarHeight: CGFloat = 24
 
     // Shared state -- subclasses modify directly
-    var isAgentActive: Bool = false
+    var isAgentActive: Bool = false {
+        didSet {
+            if oldValue != isAgentActive { updateBorderForState() }
+        }
+    }
     var processTitle: String?
     var agentState: AgentState = .idle
     var commandStartTime: Date?
@@ -69,8 +73,8 @@ class FlockPane: NSView {
         layer?.shadowOpacity = Theme.Shadow.Rest.contact.opacity
         layer?.shadowRadius = Theme.Shadow.Rest.contact.radius
         layer?.shadowOffset = Theme.Shadow.Rest.contact.offset
-        layer?.borderWidth = 1
-        layer?.borderColor = Theme.borderRest.cgColor
+        layer?.borderWidth = paneType == .claude ? 1.5 : 1
+        layer?.borderColor = (paneType == .claude ? NSColor(hex: 0x4A90D9) : Theme.borderRest).cgColor
 
         // Ambient shadow
         ambientShadowLayer.shadowColor = NSColor.black.cgColor
@@ -141,7 +145,11 @@ class FlockPane: NSView {
 
     @objc private func baseThemeDidChange() {
         layer?.backgroundColor = Theme.surface.cgColor
-        layer?.borderColor = (isFocused ? Theme.borderFocus : Theme.borderRest).cgColor
+        if paneType == .claude {
+            layer?.borderColor = (isFocused ? NSColor(hex: 0x6AB0FF) : NSColor(hex: 0x4A90D9)).cgColor
+        } else {
+            layer?.borderColor = (isFocused ? Theme.borderFocus : Theme.borderRest).cgColor
+        }
         ambientShadowLayer.backgroundColor = Theme.surface.cgColor
         dimOverlayLayer.backgroundColor = Theme.chrome.withAlphaComponent(0.04).cgColor
         paneTitleBar.layer?.backgroundColor = Theme.surface.cgColor
@@ -152,6 +160,33 @@ class FlockPane: NSView {
 
     /// Override point for subclass-specific theme updates.
     func themeDidChange() {}
+
+    // MARK: - Claude border state
+
+    /// Updates the border color and width based on Claude activity.
+    /// Red = actively outputting, Blue = idle/waiting for prompt.
+    func updateBorderForState() {
+        guard paneType == .claude else { return }
+
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(Theme.Anim.fast)
+        CATransaction.setAnimationTimingFunction(Theme.Anim.snappyTimingFunction)
+
+        if agentState == .error {
+            layer?.borderWidth = 2
+            layer?.borderColor = NSColor(hex: 0xFF3B30).cgColor
+        } else if isAgentActive {
+            // Claude is actively outputting — red
+            layer?.borderWidth = 2
+            layer?.borderColor = NSColor(hex: 0xE05545).cgColor
+        } else {
+            // Idle — blue
+            layer?.borderWidth = 1.5
+            layer?.borderColor = (isFocused ? NSColor(hex: 0x6AB0FF) : NSColor(hex: 0x4A90D9)).cgColor
+        }
+
+        CATransaction.commit()
+    }
 
     // MARK: - Accent bar
 
@@ -171,13 +206,20 @@ class FlockPane: NSView {
         CATransaction.setAnimationDuration(Theme.Anim.normal)
         CATransaction.setAnimationTimingFunction(Theme.Anim.snappyTimingFunction)
 
-        layer?.borderWidth = 1
+        // If Claude pane is actively working, keep the red border
+        let claudeIsWorking = paneType == .claude && (isAgentActive || agentState == .error)
+
+        if !claudeIsWorking {
+            layer?.borderWidth = paneType == .claude ? 1.5 : 1
+        }
 
         if isFocused {
             layer?.shadowOpacity = Theme.Shadow.Focus.contact.opacity
             layer?.shadowRadius = Theme.Shadow.Focus.contact.radius
             layer?.shadowOffset = Theme.Shadow.Focus.contact.offset
-            layer?.borderColor = Theme.borderFocus.cgColor
+            if !claudeIsWorking {
+                layer?.borderColor = (paneType == .claude ? NSColor(hex: 0x6AB0FF) : Theme.borderFocus).cgColor
+            }
             ambientShadowLayer.shadowOpacity = Theme.Shadow.Focus.ambient.opacity
             ambientShadowLayer.shadowRadius = Theme.Shadow.Focus.ambient.radius
             ambientShadowLayer.shadowOffset = Theme.Shadow.Focus.ambient.offset
@@ -186,7 +228,9 @@ class FlockPane: NSView {
             layer?.shadowOpacity = Theme.Shadow.Rest.contact.opacity
             layer?.shadowRadius = Theme.Shadow.Rest.contact.radius
             layer?.shadowOffset = Theme.Shadow.Rest.contact.offset
-            layer?.borderColor = Theme.borderRest.cgColor
+            if !claudeIsWorking {
+                layer?.borderColor = (paneType == .claude ? NSColor(hex: 0x4A90D9) : Theme.borderRest).cgColor
+            }
             ambientShadowLayer.shadowOpacity = Theme.Shadow.Rest.ambient.opacity
             ambientShadowLayer.shadowRadius = Theme.Shadow.Rest.ambient.radius
             ambientShadowLayer.shadowOffset = Theme.Shadow.Rest.ambient.offset

--- a/Sources/Flock/FlockPane.swift
+++ b/Sources/Flock/FlockPane.swift
@@ -23,6 +23,7 @@ class FlockPane: NSView {
     let paneTitleBar = NSView(frame: .zero)
     let titleProcessLabel = NSTextField(labelWithString: "")
     let titleCwdLabel = NSTextField(labelWithString: "")
+    let titleCostLabel = NSTextField(labelWithString: "")
     let titleBarHeight: CGFloat = 24
 
     // Shared state -- subclasses modify directly
@@ -124,6 +125,16 @@ class FlockPane: NSView {
         titleCwdLabel.lineBreakMode = .byTruncatingMiddle
         paneTitleBar.addSubview(titleCwdLabel)
 
+        // Cost label (Claude panes only)
+        titleCostLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .medium)
+        titleCostLabel.textColor = Theme.textTertiary
+        titleCostLabel.alignment = .right
+        titleCostLabel.isBezeled = false
+        titleCostLabel.drawsBackground = false
+        titleCostLabel.isEditable = false
+        titleCostLabel.isHidden = paneType != .claude
+        paneTitleBar.addSubview(titleCostLabel)
+
         updateTitleBar()
 
         // Theme observer
@@ -155,6 +166,7 @@ class FlockPane: NSView {
         paneTitleBar.layer?.backgroundColor = Theme.surface.cgColor
         titleProcessLabel.textColor = Theme.textSecondary
         titleCwdLabel.textColor = Theme.textTertiary
+        titleCostLabel.textColor = Theme.textTertiary
         themeDidChange()
     }
 
@@ -293,8 +305,18 @@ class FlockPane: NSView {
         paneTitleBar.frame = CGRect(x: 0, y: 0, width: clipView.bounds.width, height: titleBarHeight)
         let labelH: CGFloat = 16
         let labelY = (titleBarHeight - labelH) / 2
-        titleProcessLabel.frame = CGRect(x: 8, y: labelY, width: paneTitleBar.bounds.width / 2 - 12, height: labelH)
-        titleCwdLabel.frame = CGRect(x: paneTitleBar.bounds.width / 2, y: labelY, width: paneTitleBar.bounds.width / 2 - 8, height: labelH)
+        // Measure cost label width dynamically
+        var costW: CGFloat = 0
+        if !titleCostLabel.isHidden && !titleCostLabel.stringValue.isEmpty {
+            titleCostLabel.sizeToFit()
+            costW = ceil(titleCostLabel.frame.width) + 8  // 8px breathing room
+        }
+        let barW = paneTitleBar.bounds.width
+        titleProcessLabel.frame = CGRect(x: 8, y: labelY, width: barW / 2 - 12, height: labelH)
+        titleCwdLabel.frame = CGRect(x: barW / 2, y: labelY, width: barW / 2 - 8 - costW, height: labelH)
+        if costW > 0 {
+            titleCostLabel.frame = CGRect(x: barW - costW - 8, y: labelY, width: costW, height: labelH)
+        }
         ambientShadowLayer.frame = bounds
         dimOverlayLayer.frame = bounds
         accentBarLayer.frame = CGRect(x: 4, y: 0, width: bounds.width - 8, height: 3)

--- a/Sources/Flock/FlockTerminalView.swift
+++ b/Sources/Flock/FlockTerminalView.swift
@@ -7,6 +7,9 @@ class FlockTerminalView: LocalProcessTerminalView {
     // Scroll-lock: track whether the user has scrolled away from the bottom
     private var isUserScrolledBack: Bool = false
 
+    // Typing detection: suppress activity indicator for keyboard echo
+    var lastUserInputTime: CFAbsoluteTime = 0
+
     override func scrollWheel(with event: NSEvent) {
         super.scrollWheel(with: event)
         let atBottom = !canScroll || scrollPosition >= 0.999
@@ -84,6 +87,8 @@ class FlockTerminalView: LocalProcessTerminalView {
         // User typed something — release scroll lock so output follows naturally
         isUserScrolledBack = false
         terminal.userScrolling = false
+        // Mark input time so we can suppress echo in activity detection
+        lastUserInputTime = CFAbsoluteTimeGetCurrent()
         super.send(source: source, data: data)
         guard let manager = owningPane?.manager, manager.isBroadcasting else { return }
         let snapshot = manager.panes

--- a/Sources/Flock/FlockTerminalView.swift
+++ b/Sources/Flock/FlockTerminalView.swift
@@ -4,9 +4,21 @@ import SwiftTerm
 class FlockTerminalView: LocalProcessTerminalView {
     weak var owningPane: TerminalPane?
 
+    // Scroll-lock: track whether the user has scrolled away from the bottom
+    private var isUserScrolledBack: Bool = false
+
+    override func scrollWheel(with event: NSEvent) {
+        super.scrollWheel(with: event)
+        let atBottom = !canScroll || scrollPosition >= 0.999
+        isUserScrolledBack = !atBottom
+        terminal.userScrolling = isUserScrolledBack
+    }
+
     // Detect output for activity dots + agent state parsing + compression analytics
     private var utf8Remainder = Data()
     override func dataReceived(slice: ArraySlice<UInt8>) {
+        // Preserve user scroll position OR active selection: set flag BEFORE feed processes data
+        terminal.userScrolling = isUserScrolledBack || selectionActive
         super.dataReceived(slice: slice)
         let count = slice.count
         // Copy bytes NOW -- the backing buffer may be recycled before main runs
@@ -69,6 +81,9 @@ class FlockTerminalView: LocalProcessTerminalView {
 
     // Broadcast input: when typing in one pane, send to all others
     override func send(source: TerminalView, data: ArraySlice<UInt8>) {
+        // User typed something — release scroll lock so output follows naturally
+        isUserScrolledBack = false
+        terminal.userScrolling = false
         super.send(source: source, data: data)
         guard let manager = owningPane?.manager, manager.isBroadcasting else { return }
         let snapshot = manager.panes

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -332,6 +332,10 @@ class PaneManager {
     }
 
     func saveSession() {
+        // Capture each Claude pane's session ID from its running process before saving
+        for pane in panes {
+            (pane as? TerminalPane)?.captureSessionId()
+        }
         let tabs = tabNodes.map { encodeNode($0) }
         SessionRestore.save(tabs: tabs, activeIndex: activePaneIndex)
     }
@@ -351,11 +355,23 @@ class PaneManager {
         if let mp = pane as? MarkdownPane {
             return SessionPane(type: "markdown", workingDirectory: mp.filePath, customName: mp.customName, sessionId: nil)
         }
+        // Try multiple sources for working directory:
+        // 1. OSC 7 reported directory (most accurate when shell is in foreground)
+        // 2. CWD from the running process via proc_pidinfo (works even when Claude is active)
+        // 3. contextDirectory (the initial directory from pane creation)
+        let termPane = pane as? TerminalPane
+        let dir = pane.currentDirectory
+            ?? termPane?.processWorkingDirectory()
+            ?? termPane?.contextDirectory
+        // Use the session ID captured from the process's open files at shutdown
+        let sessionId: String? = pane.paneType == .claude
+            ? termPane?.resumeSessionId ?? "resume"
+            : nil
         return SessionPane(
             type: pane.paneType == .claude ? "claude" : "shell",
-            workingDirectory: pane.currentDirectory,
+            workingDirectory: dir,
             customName: pane.customName,
-            sessionId: pane.paneType == .claude ? "resume" : nil
+            sessionId: sessionId
         )
     }
 
@@ -414,8 +430,9 @@ class PaneManager {
         let type: PaneType = sp.type == "shell" ? .shell : .claude
         let pane = TerminalPane(type: type, manager: self, workingDirectory: sp.workingDirectory)
         pane.customName = sp.customName
-        if type == .claude, sp.sessionId != nil {
+        if type == .claude, let sid = sp.sessionId {
             pane.shouldResume = true
+            pane.resumeSessionId = sid
         }
         return pane
     }

--- a/Sources/Flock/TerminalPane.swift
+++ b/Sources/Flock/TerminalPane.swift
@@ -14,6 +14,18 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
     private var byteWindowTimer: Timer?
     private let byteRateThreshold: Int = 150  // bytes per second to count as "active"
 
+    // Per-session cost tracking (Claude panes only)
+    private var sessionCostUSD: Double = 0
+    private var sessionTokens: Int = 0
+    private var sessionInputTokens: Int = 0
+    private var sessionOutputTokens: Int = 0
+    private var sessionCacheReadTokens: Int = 0
+    private var sessionCacheCreateTokens: Int = 0
+    private var lastCostLineCount: Int = 0
+    private var costUpdateTimer: Timer?
+    private var costStatsView: CostStatsView?
+    private(set) var isCostStatsVisible: Bool = false
+
     // Agent state parsing (Claude panes only)
     let outputParser = ClaudeOutputParser()
 
@@ -104,6 +116,13 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
                 } else {
                     self.sendText("claude --dangerously-skip-permissions\n")
                 }
+
+                // Initial cost refresh for restored sessions
+                if self.shouldResume {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                        self?.refreshSessionCost()
+                    }
+                }
             }
         }
 
@@ -167,6 +186,193 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
         }
     }
 
+    // MARK: - Per-session cost tracking
+
+    // Pricing per million tokens (from LiteLLM, updated 2026-04)
+    private static let costPricing: [String: (input: Double, output: Double, cacheRead: Double, cacheCreate: Double)] = [
+        "claude-opus-4-6":            (5.0,   25.0,  0.50,  6.25),
+        "claude-opus-4-5-20251101":   (5.0,   25.0,  0.50,  6.25),
+        "claude-sonnet-4-5-20250929": (3.0,   15.0,  0.30,  3.75),
+        "claude-sonnet-4-6":          (3.0,   15.0,  0.30,  3.75),
+        "claude-haiku-4-5-20251001":  (0.80,  4.0,   0.08,  1.0),
+    ]
+    private static let defaultCostPricing = (input: 3.0, output: 15.0, cacheRead: 0.30, cacheCreate: 3.75)
+
+    /// Schedules a cost update shortly after output arrives (debounced).
+    private func scheduleCostUpdate() {
+        guard paneType == .claude else { return }
+        costUpdateTimer?.invalidate()
+        costUpdateTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+            self?.refreshSessionCost()
+        }
+    }
+
+    /// Reads the session JSONL file and computes cost for this session only.
+    private func refreshSessionCost() {
+        guard let sid = resumeSessionId, !sid.isEmpty, sid != "resume",
+              let dir = contextDirectory ?? processWorkingDirectory() else { return }
+
+        let encoded = dir.replacingOccurrences(of: "/", with: "-")
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let filePath = "\(home)/.claude/projects/\(encoded)/\(sid).jsonl"
+
+        // Read on background thread
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self,
+                  let data = FileManager.default.contents(atPath: filePath),
+                  let content = String(data: data, encoding: .utf8) else { return }
+
+            var cost: Double = 0
+            var tokens: Int = 0
+            var inputTok: Int = 0
+            var outputTok: Int = 0
+            var cacheReadTok: Int = 0
+            var cacheCreateTok: Int = 0
+            let lines = content.split(separator: "\n")
+
+            // Only parse new lines since last check
+            let startLine = self.lastCostLineCount
+            guard lines.count > startLine else { return }
+
+            for i in startLine..<lines.count {
+                let line = lines[i]
+                guard line.contains("\"type\":\"assistant\"") || line.contains("\"type\": \"assistant\"") else { continue }
+
+                guard let lineData = line.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                      json["type"] as? String == "assistant",
+                      let message = json["message"] as? [String: Any],
+                      let usage = message["usage"] as? [String: Any] else { continue }
+
+                let input = usage["input_tokens"] as? Int ?? 0
+                let output = usage["output_tokens"] as? Int ?? 0
+                let cacheRead = usage["cache_read_input_tokens"] as? Int ?? 0
+                let cacheCreate = usage["cache_creation_input_tokens"] as? Int ?? 0
+                let model = message["model"] as? String ?? ""
+
+                tokens += input + output
+                inputTok += input
+                outputTok += output
+                cacheReadTok += cacheRead
+                cacheCreateTok += cacheCreate
+                let p = Self.costPricing[model] ?? Self.defaultCostPricing
+                let baseInput = max(0, input - cacheRead - cacheCreate)
+                cost += Double(baseInput) / 1_000_000 * p.input
+                     + Double(output) / 1_000_000 * p.output
+                     + Double(cacheRead) / 1_000_000 * p.cacheRead
+                     + Double(cacheCreate) / 1_000_000 * p.cacheCreate
+            }
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.sessionCostUSD += cost
+                self.sessionTokens += tokens
+                self.sessionInputTokens += inputTok
+                self.sessionOutputTokens += outputTok
+                self.sessionCacheReadTokens += cacheReadTok
+                self.sessionCacheCreateTokens += cacheCreateTok
+                self.lastCostLineCount = lines.count
+                self.updateCostLabel()
+                self.updateCostStatsIfVisible()
+            }
+        }
+    }
+
+    private func updateCostLabel() {
+        guard paneType == .claude else { return }
+        let cost = sessionCostUSD
+        let costStr: String
+        if cost == 0 {
+            costStr = "$0.00"
+        } else if cost < 0.01 {
+            costStr = "<$0.01"
+        } else if cost < 10 {
+            costStr = String(format: "$%.2f", cost)
+        } else {
+            costStr = String(format: "$%.0f", cost)
+        }
+
+        let tokens = sessionTokens
+        let tokenStr: String
+        if tokens < 1000 {
+            tokenStr = "\(tokens)"
+        } else if tokens < 1_000_000 {
+            tokenStr = String(format: "%.1fK", Double(tokens) / 1000)
+        } else {
+            tokenStr = String(format: "%.1fM", Double(tokens) / 1_000_000)
+        }
+
+        let prev = titleCostLabel.stringValue
+        titleCostLabel.stringValue = "\(costStr) · \(tokenStr)"
+
+        // Animate on change
+        if prev != titleCostLabel.stringValue && !prev.isEmpty {
+            titleCostLabel.alphaValue = 0.3
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = Theme.Anim.fast
+                self.titleCostLabel.animator().alphaValue = 1.0
+            }
+        }
+    }
+
+    // MARK: - Cost stats panel
+
+    func toggleCostStats() {
+        guard paneType == .claude else { return }
+        if isCostStatsVisible { hideCostStats() } else { showCostStats() }
+    }
+
+    private func showCostStats() {
+        guard costStatsView == nil else { return }
+        let panel = CostStatsView(frame: .zero)
+        panel.onClose = { [weak self] in self?.hideCostStats() }
+        panel.update(
+            sessionCost: sessionCostUSD, sessionTokens: sessionTokens,
+            inputTokens: sessionInputTokens, outputTokens: sessionOutputTokens,
+            cacheReadTokens: sessionCacheReadTokens, cacheCreateTokens: sessionCacheCreateTokens
+        )
+        let h = panel.idealHeight()
+        let x = clipView.bounds.width - panel.panelWidth - 8
+        let y = titleBarHeight + 4
+        panel.frame = NSRect(x: x, y: y, width: panel.panelWidth, height: h)
+        panel.alphaValue = 0
+        clipView.addSubview(panel)
+        costStatsView = panel
+        isCostStatsVisible = true
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = Theme.Anim.normal
+            ctx.timingFunction = Theme.Anim.snappyTimingFunction
+            panel.animator().alphaValue = 1
+        }
+    }
+
+    private func hideCostStats() {
+        guard let panel = costStatsView else { return }
+        isCostStatsVisible = false
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = Theme.Anim.fast
+            ctx.timingFunction = Theme.Anim.snappyTimingFunction
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            panel.removeFromSuperview()
+            self?.costStatsView = nil
+        })
+    }
+
+    private func updateCostStatsIfVisible() {
+        guard isCostStatsVisible, let panel = costStatsView else { return }
+        panel.update(
+            sessionCost: sessionCostUSD, sessionTokens: sessionTokens,
+            inputTokens: sessionInputTokens, outputTokens: sessionOutputTokens,
+            cacheReadTokens: sessionCacheReadTokens, cacheCreateTokens: sessionCacheCreateTokens
+        )
+        let h = panel.idealHeight()
+        let x = clipView.bounds.width - panel.panelWidth - 8
+        let y = titleBarHeight + 4
+        panel.frame = NSRect(x: x, y: y, width: panel.panelWidth, height: h)
+    }
+
     // MARK: - Agent activity detection
 
     func didReceiveOutput(byteCount: Int) {
@@ -195,6 +401,8 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
                         guard let self, self.isAgentActive else { return }
                         self.isAgentActive = false
                         self.manager?.tabBar?.update()
+                        // Claude went idle — new tokens likely written to JSONL
+                        self.scheduleCostUpdate()
                     }
                 }
             }
@@ -321,6 +529,7 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
     }
 
     override func shutdown() {
+        costUpdateTimer?.invalidate()
         if let dir = zdotdir { ShellEnhancer.cleanup(zdotdir: dir) }
         terminalView.terminate()
     }

--- a/Sources/Flock/TerminalPane.swift
+++ b/Sources/Flock/TerminalPane.swift
@@ -1,13 +1,15 @@
 import AppKit
+import Darwin.POSIX
 import SwiftTerm
 
 class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
     let terminalView: FlockTerminalView
     var shouldResume: Bool = false
+    var resumeSessionId: String?  // Exact Claude session UUID to resume
 
     // Agent activity detection (Claude panes only)
     private var agentActivityTimer: Timer?
-    private let agentIdleTimeout: TimeInterval = 2.5
+    private let agentIdleTimeout: TimeInterval = 1.2
     private var recentByteCount: Int = 0
     private var byteWindowTimer: Timer?
     private let byteRateThreshold: Int = 150  // bytes per second to count as "active"
@@ -15,8 +17,8 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
     // Agent state parsing (Claude panes only)
     let outputParser = ClaudeOutputParser()
 
-    // Initial directory (for context file writes)
-    private var contextDirectory: String?
+    // Initial directory (for context file writes and session restore)
+    private(set) var contextDirectory: String?
 
     // Temp ZDOTDIR for shell enhancements (cleaned up on shutdown)
     private var zdotdir: String?
@@ -44,12 +46,20 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
             self.agentState = state
 
             self.updateTitleBar()
+            self.updateBorderForState()
             self.manager?.tabBar?.update()
             self.manager?.statusBar?.update()
         }
 
         outputParser.onAction = { [weak self] entry in
             self?.changeLogView?.addAction(entry)
+        }
+
+        // Auto-accept workspace trust prompt
+        outputParser.onTrustPrompt = { [weak self] in
+            guard let self else { return }
+            NSLog("[Flock] Trust prompt detected in pane, auto-accepting")
+            self.sendText("\r")
         }
 
         // Terminal
@@ -75,13 +85,25 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
         if type == .claude {
             contextDirectory = workingDirectory ?? FileManager.default.homeDirectoryForCurrentUser.path
-            if let dir = contextDirectory, Settings.shared.memoryEnabled {
-                MemoryStore.shared.writeContextFile(to: dir)
-            }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 guard let self else { return }
-                self.sendText(self.shouldResume ? "claude --resume\n" : "claude\n")
+                // Write context file only for new sessions (not resume) to avoid
+                // triggering file-change permission prompts in Claude
+                if !self.shouldResume, let dir = self.contextDirectory, Settings.shared.memoryEnabled {
+                    MemoryStore.shared.writeContextFile(to: dir)
+                }
+                if self.shouldResume {
+                    if let sid = self.resumeSessionId, sid != "resume" {
+                        // Resume exact conversation by session ID
+                        self.sendText("claude --resume \(sid) --dangerously-skip-permissions\n")
+                    } else {
+                        // Fallback: continue most recent conversation in this directory
+                        self.sendText("claude -c --dangerously-skip-permissions\n")
+                    }
+                } else {
+                    self.sendText("claude --dangerously-skip-permissions\n")
+                }
             }
         }
 
@@ -149,6 +171,10 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     func didReceiveOutput(byteCount: Int) {
         guard paneType == .claude && Settings.shared.showActivityIndicators else { return }
+
+        // Ignore keyboard echo — if user typed recently, this is likely just echo
+        let timeSinceInput = CFAbsoluteTimeGetCurrent() - terminalView.lastUserInputTime
+        if timeSinceInput < 0.3 { return }
 
         recentByteCount += byteCount
 
@@ -241,6 +267,59 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     func sendText(_ text: String) { terminalView.send(txt: text) }
 
+    /// Returns the current working directory of the shell process via proc_pidinfo.
+    /// Works even when Claude Code is the active foreground process, because the
+    /// shell's CWD reflects where it was when claude was launched.
+    func processWorkingDirectory() -> String? {
+        let pid = terminalView.process.shellPid
+        guard pid > 0 else { return nil }
+        var pathInfo = proc_vnodepathinfo()
+        let size = Int32(MemoryLayout<proc_vnodepathinfo>.size)
+        let result = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &pathInfo, size)
+        guard result == size else { return nil }
+        return withUnsafePointer(to: pathInfo.pvi_cdir.vip_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) {
+                String(cString: $0)
+            }
+        }
+    }
+
+    // MARK: - Session ID capture
+
+    /// Captures the Claude session ID by reading ~/.claude/sessions/<PID>.json.
+    /// Claude writes a JSON file named by its PID that contains the sessionId.
+    /// Each pane's shell has one Claude child → its PID maps to exactly one session.
+    func captureSessionId() {
+        guard paneType == .claude else { return }
+        let shellPid = terminalView.process.shellPid
+        guard shellPid > 0 else { return }
+
+        // Find the Claude child process of our shell
+        let maxPids = 4096
+        var allPids = [pid_t](repeating: 0, count: maxPids)
+        let pidBytes = proc_listpids(UInt32(PROC_ALL_PIDS), 0, &allPids, Int32(maxPids * MemoryLayout<pid_t>.size))
+        let pidCount = Int(pidBytes) / MemoryLayout<pid_t>.size
+
+        for i in 0..<pidCount {
+            let pid = allPids[i]
+            guard pid > 0 else { continue }
+
+            var taskInfo = proc_bsdshortinfo()
+            let infoSize = proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &taskInfo, Int32(MemoryLayout<proc_bsdshortinfo>.size))
+            guard infoSize > 0, taskInfo.pbsi_ppid == UInt32(shellPid) else { continue }
+
+            // Found child of our shell — read ~/.claude/sessions/<PID>.json
+            let sessionFile = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".claude/sessions/\(pid).json")
+            guard let data = try? Data(contentsOf: sessionFile),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let sessionId = json["sessionId"] as? String else { continue }
+
+            resumeSessionId = sessionId
+            return
+        }
+    }
+
     override func shutdown() {
         if let dir = zdotdir { ShellEnhancer.cleanup(zdotdir: dir) }
         terminalView.terminate()
@@ -250,7 +329,12 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     override func layoutContent() {
         let pad: CGFloat = 8
-        terminalView.frame = CGRect(x: pad, y: titleBarHeight, width: clipView.bounds.width - pad * 2, height: clipView.bounds.height - titleBarHeight - pad)
+        let newFrame = CGRect(x: pad, y: titleBarHeight, width: clipView.bounds.width - pad * 2, height: clipView.bounds.height - titleBarHeight - pad)
+        // Only set frame if it actually changed — setting it unconditionally
+        // triggers SwiftTerm's internal layout which resets scroll position
+        if terminalView.frame != newFrame {
+            terminalView.frame = newFrame
+        }
 
         // Reposition change log overlay if visible
         if let panel = changeLogView {

--- a/Sources/Flock/main.swift
+++ b/Sources/Flock/main.swift
@@ -208,6 +208,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         (paneManager.panes[idx] as? TerminalPane)?.toggleChangeLog()
     }
 
+    @objc func toggleCostStats(_ sender: Any?) {
+        let idx = paneManager.activePaneIndex
+        guard idx >= 0, idx < paneManager.panes.count else { return }
+        (paneManager.panes[idx] as? TerminalPane)?.toggleCostStats()
+    }
+
     @objc func checkForUpdates(_ sender: Any?) {
         UpdateChecker.shared.checkNow()
     }
@@ -270,6 +276,8 @@ func buildMainMenu(target: AppDelegate) -> NSMenu {
             key: "m", mods: [.command, .shift], target: target)
     addItem(viewMenu, "Toggle Change Log", #selector(AppDelegate.toggleChangeLog(_:)),
             key: "l", mods: [.command, .shift], target: target)
+    addItem(viewMenu, "Toggle Usage Stats", #selector(AppDelegate.toggleCostStats(_:)),
+            key: "u", mods: [.command, .shift], target: target)
 
     // -- Pane menu --
     let paneItem = NSMenuItem(); main.addItem(paneItem)


### PR DESCRIPTION
## Summary

Three major improvements to the Flock terminal experience:

### 1. Scroll-lock & selection preservation
- Scrolling up during Claude output stays in position (no snap to bottom)
- Text selection persists while new output streams in
- Switching tabs no longer resets scroll position

### 2. Session restore (complete rewrite)
- **Exact session ID capture** per pane via `~/.claude/sessions/<PID>.json` at shutdown
- **Correct working directory** via `proc_pidinfo` (works even when Claude is the active process)
- **Resume with exact UUID**: `claude --resume <session-uuid>`
- **Auto-accept trust prompt** on session restore
- **Skip permission prompts**: `--dangerously-skip-permissions` on all launches

### 3. Visual pane differentiation
- **Blue border** (1.5px) for Claude panes, default for shell panes
- **Red border** (2px) when Claude is actively outputting (>150 bytes/sec)
- Returns to blue ~1.2s after output stops
- Keyboard echo suppressed from activity detection (no false positives when typing)

## Technical details

**Files changed:**
- `FlockTerminalView.swift` — scroll-lock tracking, keyboard echo timestamp
- `TerminalPane.swift` — session ID capture via libproc, CWD detection, trust auto-accept, frame guard
- `PaneManager.swift` — session capture at shutdown, CWD fallback chain (OSC 7 → proc_pidinfo → contextDirectory)
- `FlockPane.swift` — blue/red border logic, `isAgentActive` didSet, focus animation guards
- `ClaudeOutputParser.swift` — trust prompt detection with text buffering
- `SessionRestore.swift` — cleanup of unused method

**Depends on:** migueldeicaza/SwiftTerm#530 (exposes `Terminal.userScrolling` flag)

## Test plan
- [ ] Scroll up during streaming output → stays in position
- [ ] Select text during streaming → selection persists
- [ ] Switch tabs during streaming → no scroll reset
- [ ] Quit and relaunch with "Restore Last Session" → correct paths and conversations resumed
- [ ] Multiple Claude panes in same directory → each resumes its own conversation
- [ ] Trust prompt auto-accepted on restore
- [ ] Claude panes have blue border, shell panes have default
- [ ] Border turns red during Claude output, blue when idle
- [ ] Typing in prompt does NOT trigger red border

🤖 Generated with [Claude Code](https://claude.com/claude-code)