### PR TITLE
feat: hot workspaces, accurate cost tracking, agent-exit detection, and maximize fixes

### DIFF
--- a/Flock.entitlements
+++ b/Flock.entitlements
@@ -2,5 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
 </plist>

--- a/Info.plist
+++ b/Info.plist
@@ -26,6 +26,8 @@
 	<string>Flock terminal sessions need file access.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Flock needs the microphone so Claude Code's voice dictation (/voice) can transcribe your speech into the prompt.</string>
 	<key>NSRemovableVolumesUsageDescription</key>
 	<string>Flock terminal sessions need file access.</string>
 	<key>NSSupportsAutomaticTermination</key>

--- a/Sources/Flock/CommandPalette.swift
+++ b/Sources/Flock/CommandPalette.swift
@@ -154,6 +154,9 @@ class CommandPalette {
                 guard let win = self?.window else { return }
                 PreferencesView.show(on: win)
             },
+            CommandAction(name: "Allow Microphone (Voice Dictation)", shortcut: "", category: "View") {
+                VoiceMode.promptOrOpenSettings()
+            },
             CommandAction(name: "Find in Terminal", shortcut: "⌘F", category: "View") { [weak self] in
                 self?.paneManager?.showFindBar()
             },

--- a/Sources/Flock/CommandPalette.swift
+++ b/Sources/Flock/CommandPalette.swift
@@ -215,7 +215,36 @@ class CommandPalette {
                 Settings.shared.themeId = theme.id
                 Theme.active = theme
             }
+        } + workspaceActions()
+    }
+
+    private func workspaceActions() -> [CommandAction] {
+        var actions: [CommandAction] = [
+            CommandAction(name: "New Workspace", shortcut: "⌘⌃N", category: "Workspaces") { [weak self] in
+                self?.paneManager?.addWorkspace()
+            },
+            CommandAction(name: "Next Workspace", shortcut: "⌘⌃]", category: "Workspaces") { [weak self] in
+                self?.paneManager?.cycleWorkspace(forward: true)
+            },
+            CommandAction(name: "Previous Workspace", shortcut: "⌘⌃[", category: "Workspaces") { [weak self] in
+                self?.paneManager?.cycleWorkspace(forward: false)
+            },
+            CommandAction(name: "Rename Workspace", shortcut: "", category: "Workspaces") {
+                NSApp.sendAction(#selector(AppDelegate.renameWorkspace(_:)), to: nil, from: nil)
+            },
+            CommandAction(name: "Close Workspace", shortcut: "⌘⌃W", category: "Workspaces") { [weak self] in
+                self?.paneManager?.closeActiveWorkspace()
+            },
+        ]
+        // One "Switch to <name>" entry per existing workspace.
+        if let mgr = paneManager {
+            for (i, ws) in mgr.workspaces.enumerated() {
+                actions.append(CommandAction(name: "Switch to: \(ws.name)", shortcut: "", category: "Workspaces") { [weak self] in
+                    self?.paneManager?.switchToWorkspace(at: i)
+                })
+            }
         }
+        return actions
     }
 
     private func applyPreset(_ preset: LayoutPreset) {

--- a/Sources/Flock/FlockPane.swift
+++ b/Sources/Flock/FlockPane.swift
@@ -212,11 +212,15 @@ class FlockPane: NSView {
 
     // MARK: - Claude border state
 
+    /// Whether to render the Claude session borders. TerminalPane overrides this
+    /// to drop them once the Claude process exits (pane fell back to a shell).
+    var claudeBordersActive: Bool { paneType == .claude && claudeSessionBordersEnabled }
+
     /// Updates the border color and width based on Claude activity.
     /// Red = actively outputting, Blue = idle/waiting for prompt.
     func updateBorderForState() {
         guard paneType == .claude else { return }
-        guard claudeSessionBordersEnabled else {
+        guard claudeBordersActive else {
             layer?.borderWidth = 1
             layer?.borderColor = (isFocused ? Theme.borderFocus : Theme.borderRest).cgColor
             return
@@ -261,7 +265,7 @@ class FlockPane: NSView {
         CATransaction.setAnimationTimingFunction(Theme.Anim.snappyTimingFunction)
 
         // If Claude pane is actively working, keep the red border
-        let claudeIsWorking = paneType == .claude && claudeSessionBordersEnabled && (isAgentActive || agentState == .error)
+        let claudeIsWorking = claudeBordersActive && (isAgentActive || agentState == .error)
 
         if !claudeIsWorking {
             layer?.borderWidth = 1
@@ -272,7 +276,7 @@ class FlockPane: NSView {
             layer?.shadowRadius = Theme.Shadow.Focus.contact.radius
             layer?.shadowOffset = Theme.Shadow.Focus.contact.offset
             if !claudeIsWorking {
-                layer?.borderColor = (paneType == .claude && claudeSessionBordersEnabled ? NSColor(hex: 0x6AB0FF) : Theme.borderFocus).cgColor
+                layer?.borderColor = (claudeBordersActive ? NSColor(hex: 0x6AB0FF) : Theme.borderFocus).cgColor
             }
             ambientShadowLayer.shadowOpacity = Theme.Shadow.Focus.ambient.opacity
             ambientShadowLayer.shadowRadius = Theme.Shadow.Focus.ambient.radius
@@ -283,7 +287,7 @@ class FlockPane: NSView {
             layer?.shadowRadius = Theme.Shadow.Rest.contact.radius
             layer?.shadowOffset = Theme.Shadow.Rest.contact.offset
             if !claudeIsWorking {
-                layer?.borderColor = (paneType == .claude && claudeSessionBordersEnabled ? NSColor(hex: 0x4A90D9) : Theme.borderRest).cgColor
+                layer?.borderColor = (claudeBordersActive ? NSColor(hex: 0x4A90D9) : Theme.borderRest).cgColor
             }
             ambientShadowLayer.shadowOpacity = Theme.Shadow.Rest.ambient.opacity
             ambientShadowLayer.shadowRadius = Theme.Shadow.Rest.ambient.radius

--- a/Sources/Flock/FlockPane.swift
+++ b/Sources/Flock/FlockPane.swift
@@ -24,6 +24,7 @@ class FlockPane: NSView {
     let titleProcessLabel = NSTextField(labelWithString: "")
     let titleCwdLabel = NSTextField(labelWithString: "")
     let titleCostLabel = NSTextField(labelWithString: "")
+    let micButton = NSButton()   // voice-dictation mic indicator (Claude panes)
     let titleBarHeight: CGFloat = 24
 
     // Shared state -- subclasses modify directly
@@ -162,6 +163,20 @@ class FlockPane: NSView {
         titleCostLabel.isHidden = paneType != .claude
         paneTitleBar.addSubview(titleCostLabel)
 
+        // Voice-dictation mic indicator (Claude panes only)
+        micButton.isBordered = false
+        micButton.bezelStyle = .regularSquare
+        micButton.imagePosition = .imageOnly
+        micButton.imageScaling = .scaleProportionallyDown
+        micButton.target = self
+        micButton.action = #selector(micButtonTapped)
+        micButton.isHidden = true
+        paneTitleBar.addSubview(micButton)
+        updateMicButton()
+        // Re-check permission when returning to Flock (user may grant in Settings).
+        NotificationCenter.default.addObserver(self, selector: #selector(appBecameActive),
+                                               name: NSApplication.didBecomeActiveNotification, object: nil)
+
         updateTitleBar()
 
         // Theme observer
@@ -180,6 +195,55 @@ class FlockPane: NSView {
     func updateTitleBar() {
         titleProcessLabel.stringValue = customName ?? paneType.label
         titleCwdLabel.stringValue = ""
+    }
+
+    // MARK: - Voice dictation (microphone)
+
+    @objc private func appBecameActive() { updateMicButton() }
+
+    @objc private func micButtonTapped() {
+        switch VoiceMode.micStatus {
+        case .notDetermined:
+            VoiceMode.requestMic { [weak self] _ in self?.updateMicButton() }
+        case .denied, .restricted:
+            VoiceMode.openMicSettings()
+        case .authorized:
+            showVoiceHint()
+        @unknown default:
+            VoiceMode.requestMic { [weak self] _ in self?.updateMicButton() }
+        }
+    }
+
+    private func showVoiceHint() {
+        let alert = NSAlert()
+        alert.messageText = "Voice dictation is ready"
+        alert.informativeText = "In this Claude pane, type /voice then hold Space to dictate — your speech is transcribed into the prompt."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    /// Updates the mic indicator's visibility/icon/tooltip from the current
+    /// microphone permission. Shown only on Claude panes (where `/voice` lives).
+    func updateMicButton() {
+        guard paneType == .claude else { micButton.isHidden = true; return }
+        micButton.isHidden = false
+        let symbol: String, color: NSColor, tip: String
+        switch VoiceMode.micStatus {
+        case .authorized:
+            symbol = "mic.fill"; color = Theme.accent
+            tip = "Microphone ready — use /voice in Claude, then hold Space"
+        case .denied, .restricted:
+            symbol = "mic.slash.fill"; color = NSColor(hex: 0xFF3B30)
+            tip = "Microphone blocked — click to open System Settings"
+        default:
+            symbol = "mic"; color = Theme.textTertiary
+            tip = "Voice dictation available — click to allow the microphone"
+        }
+        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+        micButton.image = NSImage(systemSymbolName: symbol, accessibilityDescription: "Voice dictation")?
+            .withSymbolConfiguration(config)
+        micButton.contentTintColor = color
+        micButton.toolTip = tip
     }
 
     /// Override in subclasses that support full-text search outside the terminal find API.
@@ -354,7 +418,12 @@ class FlockPane: NSView {
             costW = ceil(titleCostLabel.frame.width) + 8  // 8px breathing room
         }
         let barW = paneTitleBar.bounds.width
-        titleProcessLabel.frame = CGRect(x: 8, y: labelY, width: barW / 2 - 12, height: labelH)
+        let micVisible = !micButton.isHidden
+        if micVisible {
+            micButton.frame = CGRect(x: 6, y: labelY - 1, width: 18, height: labelH + 2)
+        }
+        let procX: CGFloat = micVisible ? 26 : 8
+        titleProcessLabel.frame = CGRect(x: procX, y: labelY, width: max(20, barW / 2 - 4 - procX), height: labelH)
         titleCwdLabel.frame = CGRect(x: barW / 2, y: labelY, width: barW / 2 - 8 - costW, height: labelH)
         if costW > 0 {
             titleCostLabel.frame = CGRect(x: barW - costW - 8, y: labelY, width: costW, height: labelH)

--- a/Sources/Flock/FlockPane.swift
+++ b/Sources/Flock/FlockPane.swift
@@ -163,11 +163,15 @@ class FlockPane: NSView {
         titleCostLabel.isHidden = paneType != .claude
         paneTitleBar.addSubview(titleCostLabel)
 
-        // Voice-dictation mic indicator (Claude panes only)
+        // Voice-dictation mic indicator (Claude panes only).
+        // Styled like Flock's other SF-symbol buttons (cf. FindBarView).
         micButton.isBordered = false
-        micButton.bezelStyle = .regularSquare
+        micButton.wantsLayer = true
+        micButton.layer?.cornerRadius = 4
+        micButton.bezelStyle = .inline
+        micButton.setButtonType(.momentaryPushIn)
+        (micButton.cell as? NSButtonCell)?.highlightsBy = []
         micButton.imagePosition = .imageOnly
-        micButton.imageScaling = .scaleProportionallyDown
         micButton.target = self
         micButton.action = #selector(micButtonTapped)
         micButton.isHidden = true
@@ -239,7 +243,7 @@ class FlockPane: NSView {
             symbol = "mic"; color = Theme.textTertiary
             tip = "Voice dictation available — click to allow the microphone"
         }
-        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+        let config = NSImage.SymbolConfiguration(pointSize: 12, weight: .medium)
         micButton.image = NSImage(systemSymbolName: symbol, accessibilityDescription: "Voice dictation")?
             .withSymbolConfiguration(config)
         micButton.contentTintColor = color

--- a/Sources/Flock/MainWindow.swift
+++ b/Sources/Flock/MainWindow.swift
@@ -29,6 +29,7 @@ class FlockWindow: NSWindow {
         paneManager.tabBar = tabBar
         paneManager.gridContainer = gridContainer
         paneManager.statusBar = statusBar
+        paneManager.window = self
 
         titlebarAppearsTransparent = true
         titleVisibility = .hidden

--- a/Sources/Flock/MainWindow.swift
+++ b/Sources/Flock/MainWindow.swift
@@ -3,6 +3,7 @@ import AppKit
 class FlockWindow: NSWindow {
     let paneManager: PaneManager
     let tabBar: TabBarView
+    let workspaceBar: WorkspaceBarView
     let gridContainer: GridContainer
     let statusBar: StatusBarView
     let rootView: FlockRootView
@@ -10,6 +11,7 @@ class FlockWindow: NSWindow {
     init(paneManager: PaneManager) {
         self.paneManager = paneManager
         self.tabBar = TabBarView(paneManager: paneManager)
+        self.workspaceBar = WorkspaceBarView(paneManager: paneManager)
         self.gridContainer = GridContainer(paneManager: paneManager)
         self.statusBar = StatusBarView(paneManager: paneManager)
         self.rootView = FlockRootView()
@@ -29,6 +31,7 @@ class FlockWindow: NSWindow {
         paneManager.tabBar = tabBar
         paneManager.gridContainer = gridContainer
         paneManager.statusBar = statusBar
+        paneManager.workspaceBar = workspaceBar
         paneManager.window = self
 
         titlebarAppearsTransparent = true
@@ -45,10 +48,12 @@ class FlockWindow: NSWindow {
                                                name: Theme.themeDidChange, object: nil)
 
         rootView.tabBar = tabBar
+        rootView.workspaceBar = workspaceBar
         rootView.gridContainer = gridContainer
         rootView.statusBar = statusBar
         rootView.addSubview(rootView.tabBarEffectView)
         rootView.addSubview(tabBar)
+        rootView.addSubview(workspaceBar)
         rootView.addSubview(gridContainer)
         rootView.addSubview(statusBar)
         contentView = rootView
@@ -84,6 +89,7 @@ extension FlockWindow: NSWindowDelegate {
 
 class FlockRootView: NSView {
     weak var tabBar: NSView?
+    weak var workspaceBar: NSView?
     weak var gridContainer: NSView?
     weak var statusBar: NSView?
     let tabBarEffectView: NSVisualEffectView = {
@@ -123,10 +129,12 @@ class FlockRootView: NSView {
         let inset = titlebarInset
         let tabH = Theme.tabBarHeight + inset
         let statusH = Theme.statusHeight
+        let wsH = WorkspaceBarView.height
 
         tabBarEffectView.frame = NSRect(x: 0, y: 0, width: w, height: tabH)
         tabBar?.frame       = NSRect(x: 0, y: 0, width: w, height: tabH)
-        gridContainer?.frame = NSRect(x: 0, y: tabH, width: w, height: h - tabH - statusH)
+        workspaceBar?.frame = NSRect(x: 0, y: tabH, width: w, height: wsH)
+        gridContainer?.frame = NSRect(x: 0, y: tabH + wsH, width: w, height: h - tabH - wsH - statusH)
         statusBar?.frame    = NSRect(x: 0, y: h - statusH, width: w, height: statusH)
     }
 }

--- a/Sources/Flock/Notifications.swift
+++ b/Sources/Flock/Notifications.swift
@@ -47,7 +47,7 @@ enum FlockNotifications {
             return
         }
         lastNotification[key] = (message: body, time: now)
-        let shouldNotify = useNative
+        let shouldNotify = _useNative  // read backing field directly; `useNative` re-locks (NSLock is non-recursive → deadlock)
         lock.unlock()
 
         if shouldNotify {

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -62,6 +62,7 @@ class PaneManager {
     weak var tabBar: TabBarView?
     weak var gridContainer: GridContainer?
     weak var statusBar: StatusBarView?
+    weak var workspaceBar: WorkspaceBarView?
     weak var window: NSWindow?
 
     // Find bar
@@ -355,6 +356,7 @@ class PaneManager {
         guard !trimmed.isEmpty else { return }
         activeWorkspace.name = trimmed
         updateWindowTitle()
+        workspaceBar?.update()
         statusBar?.update()
     }
 
@@ -379,6 +381,7 @@ class PaneManager {
             tabBar?.update()
             statusBar?.update()
         }
+        workspaceBar?.update()
         updateWindowTitle()
     }
 
@@ -428,12 +431,20 @@ class PaneManager {
     }
 
     func saveSession() {
-        // Capture each Claude pane's session ID from its running process before saving
-        for pane in panes {
-            (pane as? TerminalPane)?.captureSessionId()
+        // Capture each Claude pane's session ID from its running process before
+        // saving — across every workspace, not just the active one.
+        for ws in workspaces {
+            for pane in ws.panes { (pane as? TerminalPane)?.captureSessionId() }
         }
-        let tabs = tabNodes.map { encodeNode($0) }
-        SessionRestore.save(tabs: tabs, activeIndex: activePaneIndex)
+        let datas = workspaces.map { workspaceData(for: $0) }
+        WorkspaceStore.saveAll(workspaces: datas, activeId: activeWorkspace.id)
+    }
+
+    private func workspaceData(for ws: Workspace) -> WorkspaceData {
+        let tabs = ws.tabNodes.map { encodeNode($0) }
+        let layout = SessionLayout(panes: nil, activeIndex: ws.activePaneIndex, tabs: tabs)
+        return WorkspaceData(id: ws.id, name: ws.name, colorHex: ws.colorHex,
+                             createdAt: ws.createdAt, lastUsedAt: ws.lastUsedAt, layout: layout)
     }
 
     private func encodeNode(_ node: SplitNode) -> SessionNode {
@@ -478,34 +489,33 @@ class PaneManager {
     }
 
     func restoreSession() {
-        guard let layout = SessionRestore.restore() else { return }
+        guard let loaded = WorkspaceStore.loadAll() else { return }
+        var restored: [Workspace] = []
+        for wd in loaded.workspaces {
+            let ws = Workspace(id: wd.id, name: wd.name, colorHex: wd.colorHex,
+                               createdAt: wd.createdAt, lastUsedAt: wd.lastUsedAt)
+            buildPanes(into: ws, from: wd.layout)
+            restored.append(ws)
+        }
+        guard !restored.isEmpty else { return }
+        workspaces = restored
+        activeWorkspace = restored.first { $0.id == loaded.activeId } ?? restored[0]
+        // Attach only the active workspace; the rest stay alive but detached.
+        attachActiveWorkspace()
+    }
 
+    /// Build a workspace's tab tree + panes from saved layout WITHOUT attaching
+    /// to the grid (background workspaces stay alive but detached until visited).
+    private func buildPanes(into ws: Workspace, from layout: SessionLayout) {
         if let tabs = layout.tabs {
-            // New tree-based restore
-            for tab in tabs {
-                let node = restoreNode(tab)
-                tabNodes.append(node)
-                for pane in node.allLeaves {
-                    gridContainer?.addSubview(pane)
-                }
-            }
-            rebuildPanesFromNodes()
-        } else if let flatPanes = layout.panes {
-            // Legacy flat restore
-            for sp in flatPanes {
-                let pane = restorePane(sp)
-                panes.append(pane)
-                tabNodes.append(SplitNode(pane: pane))
-                gridContainer?.addSubview(pane)
-            }
+            for tab in tabs { ws.tabNodes.append(restoreNode(tab)) }
+        } else if let flat = layout.panes {
+            for sp in flat { ws.tabNodes.append(SplitNode(pane: restorePane(sp))) }
         }
-
-        if layout.activeIndex >= 0, layout.activeIndex < panes.count {
-            focusPane(at: layout.activeIndex)
-        } else if !panes.isEmpty {
-            focusPane(at: 0)
-        }
-        layoutAndUpdate(animated: false)
+        ws.panes = ws.tabNodes.flatMap { $0.allLeaves }
+        ws.activePaneIndex = ws.panes.isEmpty
+            ? -1
+            : min(max(0, layout.activeIndex), ws.panes.count - 1)
     }
 
     private func restoreNode(_ sessionNode: SessionNode) -> SplitNode {

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -331,7 +331,7 @@ class PaneManager {
 
     private func sessionPane(for pane: FlockPane) -> SessionPane {
         if let mp = pane as? MarkdownPane {
-            return SessionPane(type: "markdown", workingDirectory: mp.filePath, customName: mp.customName, sessionId: nil)
+            return SessionPane(type: "markdown", workingDirectory: mp.filePath, customName: mp.customName, sessionId: nil, draft: nil)
         }
         // Try multiple sources for working directory:
         // 1. OSC 7 reported directory (most accurate when shell is in foreground)
@@ -355,11 +355,15 @@ class PaneManager {
         case .agent(let cli): typeString = agentLive ? "agent:\(cli.id)" : "shell"
         default: typeString = "shell"
         }
+        // Capture the unsent command line only for panes that are a shell at the
+        // prompt (not a live agent TUI).
+        let draft: String? = (termPane?.isAgentDisplayActive == false) ? termPane?.currentInputDraft() : nil
         return SessionPane(
             type: typeString,
             workingDirectory: dir,
             customName: pane.customName,
-            sessionId: sessionId
+            sessionId: sessionId,
+            draft: draft
         )
     }
 
@@ -423,7 +427,7 @@ class PaneManager {
         } else {
             type = sp.type == "shell" ? .shell : .claude
         }
-        let pane = TerminalPane(type: type, manager: self, workingDirectory: sp.workingDirectory)
+        let pane = TerminalPane(type: type, manager: self, workingDirectory: sp.workingDirectory, draft: sp.draft)
         pane.customName = sp.customName
         if type == .claude, let sid = sp.sessionId {
             pane.shouldResume = true

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -28,13 +28,41 @@ enum PaneType: Equatable {
 enum Direction { case left, right, up, down }
 
 class PaneManager {
-    private(set) var panes: [FlockPane] = []
-    private(set) var activePaneIndex: Int = -1
-    private(set) var isMaximized: Bool = false
+    // MARK: - Workspaces
+    // Each workspace keeps its panes (views + processes) alive while inactive;
+    // switching detaches the current panes from the grid and attaches the next.
+    private(set) var workspaces: [Workspace]
+    private(set) var activeWorkspace: Workspace
+
+    // Per-workspace state, proxied to the active workspace so the view layer
+    // (tabBar / statusBar / gridContainer) and every existing method keep
+    // working unchanged. Only mutated from within PaneManager.
+    var panes: [FlockPane] {
+        get { activeWorkspace.panes }
+        set { activeWorkspace.panes = newValue }
+    }
+    var activePaneIndex: Int {
+        get { activeWorkspace.activePaneIndex }
+        set { activeWorkspace.activePaneIndex = newValue }
+    }
+    var isMaximized: Bool {
+        get { activeWorkspace.isMaximized }
+        set { activeWorkspace.isMaximized = newValue }
+    }
+    var isBroadcasting: Bool {
+        get { activeWorkspace.isBroadcasting }
+        set { activeWorkspace.isBroadcasting = newValue }
+    }
+    // Split pane tree roots (one per tab) — per active workspace.
+    var tabNodes: [SplitNode] {
+        get { activeWorkspace.tabNodes }
+        set { activeWorkspace.tabNodes = newValue }
+    }
 
     weak var tabBar: TabBarView?
     weak var gridContainer: GridContainer?
     weak var statusBar: StatusBarView?
+    weak var window: NSWindow?
 
     // Find bar
     private var findBar: FindBarView?
@@ -42,11 +70,11 @@ class PaneManager {
     // Global find
     private let globalFind = GlobalFindView()
 
-    // Broadcast mode
-    private(set) var isBroadcasting: Bool = false
-
-    // Split pane tree roots (one per tab)
-    private(set) var tabNodes: [SplitNode] = []
+    init() {
+        let initial = Workspace(name: "Main")
+        self.workspaces = [initial]
+        self.activeWorkspace = initial
+    }
 
     // MARK: - Pane lifecycle
 
@@ -267,6 +295,96 @@ class PaneManager {
                 pane.layer?.add(pulse, forKey: "broadcastPulse")
             }
         }
+    }
+
+    // MARK: - Workspaces
+
+    @discardableResult
+    func addWorkspace(name: String? = nil) -> Workspace {
+        let ws = Workspace(name: name ?? "Workspace \(workspaces.count + 1)")
+        workspaces.append(ws)
+        switchTo(ws)
+        // A fresh workspace starts empty — give it a default pane.
+        if ws.panes.isEmpty { addPane(type: .claude) }
+        return ws
+    }
+
+    func switchTo(_ ws: Workspace) {
+        guard ws !== activeWorkspace, workspaces.contains(where: { $0 === ws }) else { return }
+        closeFindBar()
+        // Detach (don't shut down) the current workspace's panes — the processes
+        // keep running in the background.
+        for pane in activeWorkspace.panes {
+            pane.isFocused = false
+            pane.removeFromSuperview()
+        }
+        activeWorkspace.lastUsedAt = Date()
+        activeWorkspace = ws
+        ws.lastUsedAt = Date()
+        attachActiveWorkspace()
+    }
+
+    func switchToWorkspace(at index: Int) {
+        guard index >= 0, index < workspaces.count else { return }
+        switchTo(workspaces[index])
+    }
+
+    func cycleWorkspace(forward: Bool) {
+        guard workspaces.count > 1,
+              let i = workspaces.firstIndex(where: { $0 === activeWorkspace }) else { return }
+        let n = workspaces.count
+        switchTo(workspaces[forward ? (i + 1) % n : (i - 1 + n) % n])
+    }
+
+    func closeActiveWorkspace() {
+        guard workspaces.count > 1 else { return }   // always keep at least one
+        let closing = activeWorkspace
+        for pane in closing.panes {
+            pane.shutdown()
+            pane.removeFromSuperview()
+        }
+        let idx = workspaces.firstIndex { $0 === closing } ?? 0
+        workspaces.removeAll { $0 === closing }
+        activeWorkspace = workspaces[min(idx, workspaces.count - 1)]
+        activeWorkspace.lastUsedAt = Date()
+        attachActiveWorkspace()
+    }
+
+    func renameActiveWorkspace(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        activeWorkspace.name = trimmed
+        updateWindowTitle()
+        statusBar?.update()
+    }
+
+    /// Shut down every pane across all workspaces (called on app terminate so
+    /// background workspaces don't leave orphan processes).
+    func shutdownAllWorkspaces() {
+        for ws in workspaces {
+            for pane in ws.panes { pane.shutdown() }
+        }
+    }
+
+    /// Re-attach the active workspace's panes to the grid and restore its view
+    /// state (focus, layout, title bar).
+    private func attachActiveWorkspace() {
+        for pane in activeWorkspace.panes { gridContainer?.addSubview(pane) }
+        layoutAndUpdate(animated: false)
+        if activePaneIndex >= 0, activePaneIndex < panes.count {
+            focusPane(at: activePaneIndex)
+        } else if !panes.isEmpty {
+            focusPane(at: 0)
+        } else {
+            tabBar?.update()
+            statusBar?.update()
+        }
+        updateWindowTitle()
+    }
+
+    private func updateWindowTitle() {
+        let title: String = workspaces.count > 1 ? "\(activeWorkspace.name) — Flock" : "Flock"
+        window?.title = title
     }
 
     // MARK: - Split Panes

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -196,8 +196,27 @@ class PaneManager {
         let responder = panes[index].firstResponderView
         responder.window?.makeFirstResponder(responder)
         closeFindBar()
+
+        // En mode maximisé, la grille ne rend que le tab node actif. Sans ce
+        // relayout, changer de session met à jour la TabBar mais pas le pane
+        // affiché.
+        if isMaximized {
+            showMaximizedActiveTab(animated: true)
+        }
+
         tabBar?.update()
         statusBar?.update()
+    }
+
+    /// Affiche le tab node actif en plein écran après un changement de focus
+    /// pendant le mode maximisé. Restaure l'alpha des panes qui redeviennent
+    /// visibles (ils ont pu être laissés à alphaValue 0 par le fade-out d'entrée).
+    private func showMaximizedActiveTab(animated: Bool) {
+        gridContainer?.layoutPanes(animated: animated)   // gère isHidden par tab node
+        guard let activeTab = activeTabIndex, activeTab < tabNodes.count else { return }
+        for pane in tabNodes[activeTab].allLeaves {
+            if animated { pane.animateFadeIn() } else { pane.alphaValue = 1 }
+        }
     }
 
     func toggleMaximize() {

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -341,14 +341,18 @@ class PaneManager {
         let dir = pane.currentDirectory
             ?? termPane?.processWorkingDirectory()
             ?? termPane?.contextDirectory
+        // If the agent process has exited, the pane is really a shell now — save
+        // it as one so restore opens a shell in this directory instead of trying
+        // to relaunch/resume the agent.
+        let agentLive = termPane?.agentProcessLive ?? true
         // Use the session ID captured from the process's open files at shutdown
-        let sessionId: String? = pane.paneType == .claude
+        let sessionId: String? = (pane.paneType == .claude && agentLive)
             ? termPane?.resumeSessionId ?? "resume"
             : nil
         let typeString: String
         switch pane.paneType {
-        case .claude: typeString = "claude"
-        case .agent(let cli): typeString = "agent:\(cli.id)"
+        case .claude: typeString = agentLive ? "claude" : "shell"
+        case .agent(let cli): typeString = agentLive ? "agent:\(cli.id)" : "shell"
         default: typeString = "shell"
         }
         return SessionPane(

--- a/Sources/Flock/PaneManager.swift
+++ b/Sources/Flock/PaneManager.swift
@@ -709,6 +709,10 @@ class PaneManager {
 
     func handleClick(event: NSEvent) {
         for (i, pane) in panes.enumerated() {
+            // Skip hidden panes — in maximized mode the non-active tab's panes
+            // keep their old (quadrant) frames; without this a click inside the
+            // maximized pane could hit-test a hidden pane and switch to it.
+            if pane.isHidden { continue }
             let pt = pane.convert(event.locationInWindow, from: nil)
             if pane.bounds.contains(pt) {
                 if i != activePaneIndex { focusPane(at: i) }

--- a/Sources/Flock/SessionRestore.swift
+++ b/Sources/Flock/SessionRestore.swift
@@ -97,3 +97,82 @@ enum SessionRestore {
         try? FileManager.default.removeItem(at: sessionURL)
     }
 }
+
+// MARK: - Workspaces
+
+/// One persisted workspace: metadata + its pane/tab layout.
+struct WorkspaceData: Codable {
+    let id: String
+    let name: String
+    let colorHex: Int?
+    let createdAt: Date
+    let lastUsedAt: Date
+    let layout: SessionLayout
+}
+
+struct WorkspacesIndex: Codable {
+    let activeId: String
+    let order: [String]
+}
+
+/// Stores each workspace as its own JSON file under `workspaces/`, plus an
+/// `index.json` recording order + the active workspace. Migrates a legacy
+/// single `session.json` into one "Main" workspace on first run.
+enum WorkspaceStore {
+    private static var dir: URL {
+        let d = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Flock/workspaces")
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+    private static var indexURL: URL { dir.appendingPathComponent("index.json") }
+
+    static func saveAll(workspaces: [WorkspaceData], activeId: String) {
+        let enc = JSONEncoder()
+        let liveIds = Set(workspaces.map { $0.id })
+        for wd in workspaces {
+            if let data = try? enc.encode(wd) {
+                try? data.write(to: dir.appendingPathComponent("\(wd.id).json"), options: .atomic)
+            }
+        }
+        // Drop files for workspaces that no longer exist.
+        if let files = try? FileManager.default.contentsOfDirectory(atPath: dir.path) {
+            for f in files where f.hasSuffix(".json") && f != "index.json" {
+                let id = String(f.dropLast(".json".count))
+                if !liveIds.contains(id) {
+                    try? FileManager.default.removeItem(at: dir.appendingPathComponent(f))
+                }
+            }
+        }
+        let idx = WorkspacesIndex(activeId: activeId, order: workspaces.map { $0.id })
+        if let data = try? enc.encode(idx) {
+            try? data.write(to: indexURL, options: .atomic)
+        }
+    }
+
+    static func loadAll() -> (workspaces: [WorkspaceData], activeId: String)? {
+        let dec = JSONDecoder()
+        if let idxData = try? Data(contentsOf: indexURL),
+           let idx = try? dec.decode(WorkspacesIndex.self, from: idxData) {
+            var result: [WorkspaceData] = []
+            for id in idx.order {
+                let url = dir.appendingPathComponent("\(id).json")
+                if let d = try? Data(contentsOf: url),
+                   let wd = try? dec.decode(WorkspaceData.self, from: d) {
+                    result.append(wd)
+                }
+            }
+            guard !result.isEmpty else { return nil }
+            let active = result.contains { $0.id == idx.activeId } ? idx.activeId : result[0].id
+            return (result, active)
+        }
+
+        // Migration: wrap the legacy single session as one "Main" workspace.
+        if let legacy = SessionRestore.restore() {
+            let wd = WorkspaceData(id: UUID().uuidString, name: "Main", colorHex: nil,
+                                   createdAt: Date(), lastUsedAt: Date(), layout: legacy)
+            return ([wd], wd.id)
+        }
+        return nil
+    }
+}

--- a/Sources/Flock/SessionRestore.swift
+++ b/Sources/Flock/SessionRestore.swift
@@ -5,6 +5,7 @@ struct SessionPane: Codable {
     let workingDirectory: String?
     let customName: String?
     let sessionId: String?
+    let draft: String?      // unsent shell command line, restored on next launch
 }
 
 /// Recursive node that mirrors SplitNode for serialization.

--- a/Sources/Flock/ShellEnhancer.swift
+++ b/Sources/Flock/ShellEnhancer.swift
@@ -48,7 +48,7 @@ enum ShellEnhancer {
 
     /// Creates a temp ZDOTDIR and returns the environment array for startProcess.
     /// Returns nil if the shell isn't zsh or plugin isn't found.
-    static func enhancedEnvironment(workingDirectory: String?) -> (env: [String], zdotdir: String)? {
+    static func enhancedEnvironment(workingDirectory: String?, restoreDraft: String? = nil) -> (env: [String], zdotdir: String)? {
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         guard shell.hasSuffix("/zsh") else { return nil }
         guard let plugin = pluginPath else {
@@ -70,15 +70,36 @@ enum ShellEnhancer {
         """
         try? zshenv.write(toFile: zdotdir + "/.zshenv", atomically: true, encoding: .utf8)
 
-        // .zshrc — chain user's .zshrc, then load enhancements
+        // .zshrc — chain user's .zshrc, then load enhancements.
+        // The Flock block uses the absolute zdotdir path (not $ZDOTDIR, which is
+        // reassigned to the user's home above) and is fully guarded so it can
+        // never break shell startup on an older zsh.
         let zshrc = """
         ZDOTDIR="\(home)"
         [[ -f "\(home)/.zshrc" ]] && source "\(home)/.zshrc"
         source "\(plugin)"
         ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=244"
         ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+
+        # Flock: mirror the current command line so it can be restored next launch
+        _flock_buf="\(zdotdir)/buffer"
+        _flock_save() { printf '%s' "$BUFFER" > "$_flock_buf" 2>/dev/null }
+        _flock_clear() { : > "$_flock_buf" 2>/dev/null }
+        autoload -Uz add-zle-hook-widget 2>/dev/null
+        add-zle-hook-widget zle-line-pre-redraw _flock_save 2>/dev/null
+        add-zle-hook-widget zle-line-finish _flock_clear 2>/dev/null
+        # Flock: restore a draft command line saved from a previous session
+        if [[ -s "\(zdotdir)/restore" ]]; then
+          print -z -- "$(cat "\(zdotdir)/restore" 2>/dev/null)" 2>/dev/null
+          rm -f "\(zdotdir)/restore" 2>/dev/null
+        fi
         """
         try? zshrc.write(toFile: zdotdir + "/.zshrc", atomically: true, encoding: .utf8)
+
+        // Seed the draft to restore at the next prompt (read by the block above).
+        if let draft = restoreDraft, !draft.isEmpty {
+            try? draft.write(toFile: zdotdir + "/restore", atomically: true, encoding: .utf8)
+        }
 
         // Build environment array
         var env = ProcessInfo.processInfo.environment

--- a/Sources/Flock/TerminalPane.swift
+++ b/Sources/Flock/TerminalPane.swift
@@ -56,7 +56,7 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     override var firstResponderView: NSView { terminalView }
 
-    init(type: PaneType, manager: PaneManager, workingDirectory: String? = nil) {
+    init(type: PaneType, manager: PaneManager, workingDirectory: String? = nil, draft: String? = nil) {
         self.terminalView = FlockTerminalView(frame: .zero)
         self.agentProcessLive = type.isAgent
         super.init(type: type, manager: manager)
@@ -102,7 +102,7 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
         let name = (shell as NSString).lastPathComponent
         let cwd = workingDirectory ?? ProcessInfo.processInfo.environment["HOME"]
 
-        if let enhanced = ShellEnhancer.enhancedEnvironment(workingDirectory: workingDirectory) {
+        if let enhanced = ShellEnhancer.enhancedEnvironment(workingDirectory: workingDirectory, restoreDraft: draft) {
             self.zdotdir = enhanced.zdotdir
             terminalView.startProcess(executable: shell, environment: enhanced.env, execName: "-\(name)", currentDirectory: cwd)
         } else {
@@ -682,6 +682,16 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
             }
         }
         return false
+    }
+
+    /// The shell's current unsent command line (mirrored by the injected zsh
+    /// config), or nil if empty / unavailable. Only meaningful when the pane is
+    /// a shell at its prompt.
+    func currentInputDraft() -> String? {
+        guard let zdotdir else { return nil }
+        guard let s = try? String(contentsOfFile: zdotdir + "/buffer", encoding: .utf8),
+              !s.isEmpty else { return nil }
+        return s
     }
 
     override func shutdown() {

--- a/Sources/Flock/TerminalPane.swift
+++ b/Sources/Flock/TerminalPane.swift
@@ -195,15 +195,29 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     // MARK: - Per-session cost tracking
 
-    // Pricing per million tokens (from LiteLLM, updated 2026-04)
-    private static let costPricing: [String: (input: Double, output: Double, cacheRead: Double, cacheCreate: Double)] = [
-        "claude-opus-4-6":            (5.0,   25.0,  0.50,  6.25),
-        "claude-opus-4-5-20251101":   (5.0,   25.0,  0.50,  6.25),
-        "claude-sonnet-4-5-20250929": (3.0,   15.0,  0.30,  3.75),
-        "claude-sonnet-4-6":          (3.0,   15.0,  0.30,  3.75),
-        "claude-haiku-4-5-20251001":  (0.80,  4.0,   0.08,  1.0),
-    ]
-    private static let defaultCostPricing = (input: 3.0, output: 15.0, cacheRead: 0.30, cacheCreate: 3.75)
+    // Pricing per million tokens. Anthropic first-party rates — Opus/Sonnet are
+    // flat across the 1M context window (no >200K long-context premium). Cache
+    // rates derive from the input rate: read = 0.10x, 5m write = 1.25x, 1h write
+    // = 2.0x. Claude Code uses the 1h cache heavily, so the two write pools must
+    // be priced separately.
+    private struct ModelPricing {
+        let input: Double
+        let output: Double
+        var cacheRead: Double { input * 0.10 }
+        var cacheWrite5m: Double { input * 1.25 }
+        var cacheWrite1h: Double { input * 2.0 }
+    }
+
+    /// Resolve pricing by model-id family so aliases, future minor versions, and
+    /// dated snapshots all match (e.g. "claude-opus-4-8",
+    /// "claude-haiku-4-5-20251001"). Unknown ids fall back to Sonnet-tier.
+    private static func pricing(forModel model: String) -> ModelPricing {
+        let m = model.lowercased()
+        if m.contains("fable") || m.contains("mythos") { return ModelPricing(input: 10.0, output: 50.0) }
+        if m.contains("opus")  { return ModelPricing(input: 5.0, output: 25.0) }
+        if m.contains("haiku") { return ModelPricing(input: 1.0, output: 5.0) }
+        return ModelPricing(input: 3.0, output: 15.0)  // sonnet / default
+    }
 
     /// Schedules a cost update shortly after output arrives (debounced).
     private func scheduleCostUpdate() {
@@ -292,17 +306,30 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
                         let cacheCreate = usage["cache_creation_input_tokens"] as? Int ?? 0
                         let model = message["model"] as? String ?? ""
 
-                        tokens += input + output
+                        // Split cache-creation by TTL when present. Claude Code uses the
+                        // 1h cache heavily (billed 2x input vs 1.25x for 5m). Fall back to
+                        // treating any remainder as 5m when the breakdown is absent.
+                        let creationDetail = usage["cache_creation"] as? [String: Any]
+                        let cache1h = creationDetail?["ephemeral_1h_input_tokens"] as? Int ?? 0
+                        let cache5m = creationDetail?["ephemeral_5m_input_tokens"] as? Int
+                            ?? max(0, cacheCreate - cache1h)
+
                         inputTok += input
                         outputTok += output
                         cacheReadTok += cacheRead
                         cacheCreateTok += cacheCreate
-                        let p = Self.costPricing[model] ?? Self.defaultCostPricing
-                        let baseInput = max(0, input - cacheRead - cacheCreate)
-                        cost += Double(baseInput) / 1_000_000 * p.input
-                             + Double(output) / 1_000_000 * p.output
-                             + Double(cacheRead) / 1_000_000 * p.cacheRead
-                             + Double(cacheCreate) / 1_000_000 * p.cacheCreate
+                        // Total volume processed includes both cache pools, not just
+                        // uncached input + output.
+                        tokens += input + output + cacheRead + cacheCreate
+
+                        let p = Self.pricing(forModel: model)
+                        // input_tokens is already the uncached input — bill it at full
+                        // input rate (do NOT subtract the separate cache counters).
+                        cost += Double(input)     / 1_000_000 * p.input
+                             + Double(output)     / 1_000_000 * p.output
+                             + Double(cacheRead)  / 1_000_000 * p.cacheRead
+                             + Double(cache5m)    / 1_000_000 * p.cacheWrite5m
+                             + Double(cache1h)    / 1_000_000 * p.cacheWrite1h
                     }
                 }
             }

--- a/Sources/Flock/TerminalPane.swift
+++ b/Sources/Flock/TerminalPane.swift
@@ -79,6 +79,13 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
         // Terminal
         let fontSize = Settings.shared.fontSize
         terminalView.nativeBackgroundColor = Theme.terminalBg
+        // Keep the view's layer backing in sync with the themed terminal bg.
+        // SwiftTerm only stamps layer.backgroundColor once at init (from its
+        // default dark color) and its nativeBackgroundColor setter never
+        // refreshes it. With disableFullRedrawOnAnyChanges, a resize repaints
+        // only dirty cells, so the un-repainted area would otherwise expose the
+        // stale black backing (e.g. the black flash when un-maximizing a pane).
+        terminalView.layer?.backgroundColor = Theme.terminalBg.cgColor
         terminalView.nativeForegroundColor = Theme.terminalFg
         terminalView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
         installAnsiColors()
@@ -157,6 +164,7 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     override func themeDidChange() {
         terminalView.nativeBackgroundColor = Theme.terminalBg
+        terminalView.layer?.backgroundColor = Theme.terminalBg.cgColor
         terminalView.nativeForegroundColor = Theme.terminalFg
         installAnsiColors()
         terminalView.setNeedsDisplay(terminalView.bounds)

--- a/Sources/Flock/TerminalPane.swift
+++ b/Sources/Flock/TerminalPane.swift
@@ -28,6 +28,14 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
     private var costStatsView: CostStatsView?
     private(set) var isCostStatsVisible: Bool = false
 
+    // Agent-process liveness (Claude / agent panes only). True while the agent
+    // process is actually running; flips to false once it exits and the pane is
+    // back to a bare shell — drives the status label, borders, and what we save.
+    private(set) var agentProcessLive: Bool
+    private var hasSeenAgentAlive = false
+    private var agentPollTimer: Timer?
+    private var agentPollCount = 0
+
     // Agent state parsing (Claude panes only)
     let outputParser = ClaudeOutputParser()
 
@@ -50,6 +58,7 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
 
     init(type: PaneType, manager: PaneManager, workingDirectory: String? = nil) {
         self.terminalView = FlockTerminalView(frame: .zero)
+        self.agentProcessLive = type.isAgent
         super.init(type: type, manager: manager)
 
         terminalView.owningPane = self
@@ -133,6 +142,9 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
             }
         }
 
+        // Watch whether the agent process is alive (Claude / agent panes).
+        if type.isAgent { startAgentWatch() }
+
         // Listen for changes
         NotificationCenter.default.addObserver(self, selector: #selector(settingsChanged(_:)),
                                                name: Settings.didChange, object: nil)
@@ -180,10 +192,11 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
     // MARK: - Title bar
 
     override func updateTitleBar() {
-        let stateLabel = (agentState != .idle) ? agentState.label : nil
-        titleProcessLabel.stringValue = stateLabel ?? processTitle ?? paneType.label
-        titleProcessLabel.textColor = (agentState == .waiting) ? Theme.accent
-            : (agentState == .error) ? NSColor(hex: 0xFF3B30)
+        let agentLive = isAgentDisplayActive
+        let stateLabel = (agentLive && agentState != .idle) ? agentState.label : nil
+        titleProcessLabel.stringValue = stateLabel ?? processTitle ?? displayLabel
+        titleProcessLabel.textColor = (agentLive && agentState == .waiting) ? Theme.accent
+            : (agentLive && agentState == .error) ? NSColor(hex: 0xFF3B30)
             : Theme.textSecondary
         if let dir = currentDirectory {
             let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -574,8 +587,106 @@ class TerminalPane: FlockPane, LocalProcessTerminalViewDelegate {
         }
     }
 
+    // MARK: - Agent process watch
+
+    /// Whether the pane should currently present as its agent (Claude / CLI):
+    /// it was created as one AND that process is alive. Once the agent exits we
+    /// present as a plain shell.
+    var isAgentDisplayActive: Bool { paneType.isAgent && agentProcessLive }
+
+    /// Label shown in the title / tab: falls back to "shell" once the agent
+    /// process has exited.
+    var displayLabel: String {
+        (paneType.isAgent && !agentProcessLive) ? "shell" : paneType.label
+    }
+
+    override var claudeBordersActive: Bool {
+        super.claudeBordersActive && agentProcessLive
+    }
+
+    private func startAgentWatch() {
+        agentPollTimer?.invalidate()
+        agentPollTimer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: true) { [weak self] _ in
+            self?.pollAgentProcess()
+        }
+    }
+
+    private func pollAgentProcess() {
+        guard paneType.isAgent else { return }
+        if agentProcessIsAlive() {
+            hasSeenAgentAlive = true
+            setAgentProcessLive(true)
+        } else if hasSeenAgentAlive {
+            // We saw it running and now it's gone — it exited.
+            setAgentProcessLive(false)
+        } else {
+            // Never observed alive yet — give it a grace window to launch
+            // (slow start, or "claude" not installed) before falling back.
+            agentPollCount += 1
+            if agentPollCount >= 4 { setAgentProcessLive(false) }  // ~16s
+        }
+    }
+
+    private func setAgentProcessLive(_ live: Bool) {
+        guard live != agentProcessLive else { return }
+        agentProcessLive = live
+        if !live {
+            // Fell back to a bare shell — drop the agent state.
+            agentState = .idle
+            outputParser.reset()
+        }
+        updateTitleBar()
+        updateBorderForState()
+        manager?.tabBar?.update()
+        manager?.statusBar?.update()
+    }
+
+    /// True iff the shell has a direct child process that is this pane's agent —
+    /// for Claude, a child with a `~/.claude/sessions/<pid>.json`; for an agent
+    /// CLI, a child whose name matches the launch command.
+    private func agentProcessIsAlive() -> Bool {
+        guard let proc = terminalView.process else { return false }
+        let shellPid = proc.shellPid
+        guard shellPid > 0 else { return false }
+        let agentCmd = paneType.agentCLI?.command
+
+        // Cheap + reliable: the terminal's foreground process group. If it's the
+        // shell itself, the shell is at its prompt → no agent running.
+        let fd = proc.childfd
+        let fg: pid_t = fd >= 0 ? tcgetpgrp(fd) : -1
+        if fg > 0 && fg == shellPid { return false }
+        // For an agent CLI, any non-shell foreground program counts as the agent
+        // (its process name may differ from the command, e.g. node).
+        if fg > 0, agentCmd != nil { return true }
+
+        // Claude (or when tcgetpgrp is unavailable): scan the shell's children.
+        let maxPids = 4096
+        var pids = [pid_t](repeating: 0, count: maxPids)
+        let bytes = proc_listpids(UInt32(PROC_ALL_PIDS), 0, &pids, Int32(maxPids * MemoryLayout<pid_t>.size))
+        let count = Int(bytes) / MemoryLayout<pid_t>.size
+        for i in 0..<count {
+            let pid = pids[i]
+            guard pid > 0 else { continue }
+            var info = proc_bsdshortinfo()
+            let n = proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &info, Int32(MemoryLayout<proc_bsdshortinfo>.size))
+            guard n > 0, info.pbsi_ppid == UInt32(shellPid) else { continue }
+            // Direct child of our shell.
+            if paneType == .claude {
+                let f = FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent(".claude/sessions/\(pid).json")
+                if FileManager.default.fileExists(atPath: f.path) { return true }
+            }
+            if let agentCmd {
+                var nameBuf = [CChar](repeating: 0, count: 256)
+                if proc_name(pid, &nameBuf, 256) > 0, String(cString: nameBuf) == agentCmd { return true }
+            }
+        }
+        return false
+    }
+
     override func shutdown() {
         costUpdateTimer?.invalidate()
+        agentPollTimer?.invalidate()
         if let obs = fontSizeObserver { NotificationCenter.default.removeObserver(obs) }
         if let dir = zdotdir { ShellEnhancer.cleanup(zdotdir: dir) }
         terminalView.terminate()

--- a/Sources/Flock/VoiceMode.swift
+++ b/Sources/Flock/VoiceMode.swift
@@ -1,0 +1,39 @@
+import AVFoundation
+import AppKit
+
+/// Microphone access helper for Claude Code's voice dictation (`/voice`).
+///
+/// Claude runs inside the pane's PTY, but on macOS the host app (Flock) is the
+/// TCC subject for the microphone — so Flock must ship `NSMicrophoneUsageDescription`
+/// (Info.plist) and the hardened-runtime `com.apple.security.device.audio-input`
+/// entitlement. With those in place, macOS prompts automatically the first time
+/// Claude touches the mic; this helper also lets the UI pre-request access.
+enum VoiceMode {
+    static var micStatus: AVAuthorizationStatus {
+        AVCaptureDevice.authorizationStatus(for: .audio)
+    }
+
+    /// Triggers the system microphone prompt. The prompt only appears once
+    /// (while status is `.notDetermined`); afterwards the completion fires with
+    /// the existing decision.
+    static func requestMic(_ completion: ((Bool) -> Void)? = nil) {
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            DispatchQueue.main.async { completion?(granted) }
+        }
+    }
+
+    static func openMicSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// UI entry point: request access if undetermined, otherwise open Settings
+    /// when already denied (lets callers avoid importing AVFoundation).
+    static func promptOrOpenSettings() {
+        switch micStatus {
+        case .denied, .restricted: openMicSettings()
+        default: requestMic()
+        }
+    }
+}

--- a/Sources/Flock/Workspace.swift
+++ b/Sources/Flock/Workspace.swift
@@ -1,0 +1,33 @@
+import AppKit
+
+/// A named, hot-kept workspace. Each workspace owns its own tab tree and live
+/// panes — the pane views and their processes stay alive while the workspace is
+/// inactive. Switching workspaces detaches the current panes from the grid and
+/// attaches the next workspace's, so running shells, dev servers, and Claude
+/// sessions keep going in the background.
+final class Workspace {
+    let id: String
+    var name: String
+    var colorHex: Int?
+    let createdAt: Date
+    var lastUsedAt: Date
+
+    // Live per-workspace state (formerly stored directly on PaneManager).
+    var panes: [FlockPane] = []
+    var tabNodes: [SplitNode] = []
+    var activePaneIndex: Int = -1
+    var isMaximized: Bool = false
+    var isBroadcasting: Bool = false
+
+    init(id: String = UUID().uuidString,
+         name: String,
+         colorHex: Int? = nil,
+         createdAt: Date = Date(),
+         lastUsedAt: Date = Date()) {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
+        self.createdAt = createdAt
+        self.lastUsedAt = lastUsedAt
+    }
+}

--- a/Sources/Flock/WorkspaceBarView.swift
+++ b/Sources/Flock/WorkspaceBarView.swift
@@ -1,0 +1,108 @@
+import AppKit
+
+/// Horizontal switcher showing one chip per workspace (click to switch,
+/// double-click to rename) plus a "+" to create a new one. Sits just below the
+/// tab bar.
+final class WorkspaceBarView: NSView {
+    static let height: CGFloat = 28
+    weak var paneManager: PaneManager?
+
+    private var chipRects: [(rect: NSRect, index: Int)] = []
+    private var plusRect: NSRect = .zero
+    private let font = NSFont.systemFont(ofSize: 11, weight: .medium)
+
+    override var isFlipped: Bool { true }
+
+    init(paneManager: PaneManager) {
+        self.paneManager = paneManager
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = Theme.chrome.cgColor
+        NotificationCenter.default.addObserver(self, selector: #selector(themeChanged),
+                                               name: Theme.themeDidChange, object: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    @objc private func themeChanged() {
+        layer?.backgroundColor = Theme.chrome.cgColor
+        needsDisplay = true
+    }
+
+    func update() { needsDisplay = true }
+
+    private func attrs(_ color: NSColor) -> [NSAttributedString.Key: Any] {
+        [.font: font, .foregroundColor: color]
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let mgr = paneManager else { return }
+        chipRects.removeAll()
+
+        let chipH: CGFloat = 20
+        let y = (bounds.height - chipH) / 2
+        var x: CGFloat = Theme.Space.md
+
+        for (i, ws) in mgr.workspaces.enumerated() {
+            let isActive = ws === mgr.activeWorkspace
+            let textColor = isActive ? Theme.textPrimary : Theme.textSecondary
+            let textAttrs = attrs(textColor)
+            let size = (ws.name as NSString).size(withAttributes: textAttrs)
+            let chipW = ceil(size.width) + Theme.Space.md * 2
+            let rect = NSRect(x: x, y: y, width: chipW, height: chipH)
+
+            let path = NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6)
+            if isActive {
+                Theme.surface.setFill()
+                path.fill()
+                path.lineWidth = 1
+                Theme.accent.withAlphaComponent(0.7).setStroke()
+                path.stroke()
+            }
+            (ws.name as NSString).draw(
+                at: NSPoint(x: rect.minX + Theme.Space.md, y: rect.midY - size.height / 2),
+                withAttributes: textAttrs)
+
+            chipRects.append((rect, i))
+            x += chipW + Theme.Space.sm
+        }
+
+        // "+" button
+        plusRect = NSRect(x: x, y: y, width: chipH, height: chipH)
+        let plusAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 15, weight: .regular),
+            .foregroundColor: Theme.textTertiary,
+        ]
+        let ps = ("+" as NSString).size(withAttributes: plusAttrs)
+        ("+" as NSString).draw(
+            at: NSPoint(x: plusRect.midX - ps.width / 2, y: plusRect.midY - ps.height / 2),
+            withAttributes: plusAttrs)
+
+        // Bottom hairline
+        Theme.divider.setStroke()
+        let line = NSBezierPath()
+        line.lineWidth = 1
+        line.move(to: NSPoint(x: 0, y: bounds.maxY - 0.5))
+        line.line(to: NSPoint(x: bounds.maxX, y: bounds.maxY - 0.5))
+        line.stroke()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let mgr = paneManager else { return }
+        let pt = convert(event.locationInWindow, from: nil)
+
+        if plusRect.contains(pt) {
+            mgr.addWorkspace()
+            return
+        }
+        for (rect, index) in chipRects where rect.contains(pt) {
+            mgr.switchToWorkspace(at: index)
+            if event.clickCount >= 2 {
+                // Rename the (now active) workspace via the app delegate dialog.
+                NSApp.sendAction(#selector(AppDelegate.renameWorkspace(_:)), to: nil, from: self)
+            }
+            return
+        }
+    }
+}

--- a/Sources/Flock/main.swift
+++ b/Sources/Flock/main.swift
@@ -118,7 +118,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let observer = settingsObserver { NotificationCenter.default.removeObserver(observer); settingsObserver = nil }
 
         paneManager.saveSession()
-        paneManager.panes.forEach { $0.shutdown() }
+        paneManager.shutdownAllWorkspaces()
         return .terminateNow
     }
 
@@ -190,6 +190,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func toggleBroadcast(_ sender: Any?) {
         paneManager.toggleBroadcast()
+    }
+
+    // MARK: - Workspace actions
+
+    @objc func newWorkspace(_ sender: Any?)   { paneManager.addWorkspace() }
+    @objc func closeWorkspace(_ sender: Any?) { paneManager.closeActiveWorkspace() }
+    @objc func nextWorkspace(_ sender: Any?)  { paneManager.cycleWorkspace(forward: true) }
+    @objc func prevWorkspace(_ sender: Any?)  { paneManager.cycleWorkspace(forward: false) }
+
+    @objc func renameWorkspace(_ sender: Any?) {
+        let alert = NSAlert()
+        alert.messageText = "Rename Workspace"
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 220, height: 24))
+        field.stringValue = paneManager.activeWorkspace.name
+        alert.accessoryView = field
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            paneManager.renameActiveWorkspace(field.stringValue)
+        }
     }
 
     @objc func showGlobalFind(_ sender: Any?) {
@@ -324,6 +344,21 @@ func buildMainMenu(target: AppDelegate) -> NSMenu {
             key: String(UnicodeScalar(0xF700)!), target: target)
     addItem(paneMenu, "Navigate Down",  #selector(AppDelegate.navigateDown(_:)),
             key: String(UnicodeScalar(0xF701)!), target: target)
+
+    // -- Workspace menu --
+    let wsItem = NSMenuItem(); main.addItem(wsItem)
+    let wsMenu = NSMenu(title: "Workspace"); wsItem.submenu = wsMenu
+    addItem(wsMenu, "New Workspace", #selector(AppDelegate.newWorkspace(_:)),
+            key: "n", mods: [.command, .control], target: target)
+    addItem(wsMenu, "Close Workspace", #selector(AppDelegate.closeWorkspace(_:)),
+            key: "w", mods: [.command, .control], target: target)
+    addItem(wsMenu, "Rename Workspace…", #selector(AppDelegate.renameWorkspace(_:)),
+            key: "", mods: [], target: target)
+    wsMenu.addItem(.separator())
+    addItem(wsMenu, "Next Workspace", #selector(AppDelegate.nextWorkspace(_:)),
+            key: "]", mods: [.command, .control], target: target)
+    addItem(wsMenu, "Previous Workspace", #selector(AppDelegate.prevWorkspace(_:)),
+            key: "[", mods: [.command, .control], target: target)
 
     return main
 }

--- a/Sources/Flock/main.swift
+++ b/Sources/Flock/main.swift
@@ -10,6 +10,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var clickMonitor: Any?
     private var focusObserver: Any?
     private var settingsObserver: Any?
+    private var autosaveTimer: Timer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Notifications
@@ -55,6 +56,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Global hotkey -- always create so it can respond to settings changes
         hotkeyManager = GlobalHotkeyManager(window: mainWindow)
+
+        // Periodic autosave so multiple workspaces survive a crash (the
+        // terminate handler also saves).
+        autosaveTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
+            self?.paneManager.saveSession()
+        }
 
         // Post-update changelog tab (before update check so it doesn't stack with the alert)
         let previousVersion = Settings.shared.lastRunVersion
@@ -116,6 +123,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = clickMonitor { NSEvent.removeMonitor(monitor); clickMonitor = nil }
         if let observer = focusObserver { NotificationCenter.default.removeObserver(observer); focusObserver = nil }
         if let observer = settingsObserver { NotificationCenter.default.removeObserver(observer); settingsObserver = nil }
+        autosaveTimer?.invalidate(); autosaveTimer = nil
 
         paneManager.saveSession()
         paneManager.shutdownAllWorkspaces()


### PR DESCRIPTION
## Summary

A batch of Flock improvements — one large feature, an accuracy fix, a
hard-freeze fix, and several smaller fixes/features:

### 1. Workspaces (hot-kept)
- **Multiple named workspaces**, each with its own tab tree and panes
- **Hot switching**: switching detaches the current panes from the grid but
  **keeps their processes alive** — shells, dev servers, and Claude sessions
  keep running in the background
- **Switcher bar** under the tab bar: click to switch, double-click to rename,
  `+` to add; also `⌘⌃N` / `⌘⌃W` / `⌘⌃]` / `⌘⌃[` and a Command Palette section
- **Persistence**: each workspace is stored under
  `Application Support/Flock/workspaces/<id>.json` (+ an index); a legacy
  `session.json` is migrated into a "Main" workspace; 15s autosave + save on quit
- Implemented by making `PaneManager`'s per-workspace state a proxy onto the
  active `Workspace`, so the existing view layer needs **zero rewiring**

### 2. Accurate per-session cost tracking
The cost shown per pane is read from Claude Code's session JSONL `usage`
records, but the math under-reported by ~50% (a real Opus 4.8 session showed
~$16 vs an actual ~$32):
- **`input_tokens` is already the uncached input** — the old code subtracted the
  cache counters from it and clamped to 0, billing full-price input at $0
- **Pricing was stale/incomplete** — no entry for current models (Opus 4.8, etc.)
  so Opus fell back to Sonnet rates. Replaced with family-based resolution
  (opus 5/25, sonnet 3/15, haiku 1/5, fable 10/50)
- **Cache writes are split by TTL** — Claude Code uses the 1h cache (2× input)
  heavily; it was billed at the 5m rate (1.25×)
- The token total now includes cache read/creation, not just input + output

### 3. Agent-exit detection & shell draft restore
- When you **quit Claude** (or an agent CLI) the pane drops back to the shell;
  it now **detects this** (foreground process group via `tcgetpgrp`, with a
  Claude-session-file / child-name fallback) and flips its status to **shell** —
  title, borders, and save behavior follow (no more trying to `--resume` a shell)
- **Unsent shell command line is restored** across relaunch: the injected zsh
  config mirrors `$BUFFER` and re-fills it at the next prompt via `print -z`
  (zsh-only, fully guarded so it can't break shell startup)

### 4. Voice dictation support (`/voice`)
Claude Code's `/voice` dictation captures the microphone; on macOS the host app
is the TCC subject, but Flock shipped no microphone usage description and an
empty entitlements file while signing with hardened runtime — so the mic was
blocked and `/voice` silently failed.
- `Info.plist` gains `NSMicrophoneUsageDescription`; entitlements gain
  `com.apple.security.device.audio-input` (required under hardened runtime)
- A **mic indicator** in the Claude pane title bar shows availability and
  permission state (outline = not allowed yet, filled = ready, slashed =
  blocked), styled like Flock's other SF-symbol buttons
- Clicking it **requests microphone access** (or opens Settings when denied, or
  shows a `/voice` hint when ready); plus a Command Palette entry

### 5. Maximize fixes
- **Switching session while maximized** (`⌘R`) now swaps the visible pane —
  previously only the tab bar updated
- **No more black flash** when un-maximizing — the terminal view's layer
  background was left at SwiftTerm's stale dark default and exposed during the
  resize; it's now kept in sync with the themed terminal background
- **Clicking a maximized pane no longer jumps to a hidden pane** — the click
  hit-test now skips hidden panes (which keep stale quadrant frames)

### 6. Notifications deadlock fix (hard freeze)
`FlockNotifications.send()` took its `NSLock`, then read `useNative` whose
getter takes the same lock again — `NSLock` is non-recursive, so the main
thread deadlocked on a lock it already held (a ~59s freeze, confirmed by a
spindump). Fires whenever a command-completion notification is sent. Now reads
the `_useNative` backing field directly inside the held lock. *(Pre-existing —
present on `main` independently of the features above.)*

## Technical details

**Files changed:**
- `PaneManager.swift` — workspace model + hot switch, per-workspace state proxy,
  maximized relayout on focus, hidden-pane click fix, agent-aware session save/restore
- `TerminalPane.swift` — agent-process watch, cost rewrite, terminal-bg fix,
  shell-draft capture/replay
- `Workspace.swift` *(new)* — per-workspace live state container
- `WorkspaceBarView.swift` *(new)* — workspace switcher bar
- `VoiceMode.swift` *(new)* — microphone permission helper (AVFoundation)
- `FlockPane.swift` — `claudeBordersActive` hook, voice mic indicator
- `SessionRestore.swift` — `WorkspaceStore` (per-workspace files + migration),
  `SessionPane.draft`
- `ShellEnhancer.swift` — `$BUFFER` mirror + `print -z` draft restore
- `Notifications.swift` — fix the non-recursive `NSLock` re-entrancy deadlock
- `Info.plist` / `Flock.entitlements` — microphone usage description + entitlement
- `MainWindow.swift` / `main.swift` / `CommandPalette.swift` — switcher bar
  layout, autosave, menu + palette entries

## Test plan
- [ ] Create workspaces (`⌘⌃N`), run a long process, switch away and back → still running
- [ ] Rename via double-click; quit & relaunch → workspaces + active one restored
- [ ] Per-pane cost matches Claude Code's `/cost` for the same session
- [ ] Quit Claude in a pane → status becomes "shell", blue border drops; relaunch `claude` → back
- [ ] Type a command without Enter, quit & relaunch → command pre-filled at the prompt
- [ ] Click the mic indicator on a Claude pane → microphone prompt → `/voice` works
- [ ] Maximize a pane (`⌘R`), `⌘1`/`⌘2` or click the tab bar → visible pane changes; clicking inside stays put
- [ ] Un-maximize → no black flash during the animation
- [ ] Let a long command finish so a completion notification fires → no freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)
